### PR TITLE
Fix example for signed Call

### DIFF
--- a/example/main.js
+++ b/example/main.js
@@ -70,7 +70,7 @@ $("#send_broadcast").click(function(){
 });
 
 $("#send_signed_call").click(function(){
-  steem_keychain.requestSignedCall($("#signed_call_username").val(), $("#signed_call_method").val(), $("#signed_call_params").val(), $("#signed_call_key_type option:selected").text(), function(response) {
+  steem_keychain.requestSignedCall($("#signed_call_username").val(), $("#signed_call_method").val(), JSON.parse($("#signed_call_params").val()), $("#signed_call_key_type option:selected").text(), function(response) {
       console.log('main js response - signed call');
       console.log(response);
   });


### PR DESCRIPTION
Wraps params in json parse in example for signed call.