### PR TITLE
Allow signBuffer to take in a JSON-stringified Node-js Buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,11 @@ Where "message" is any string and "key_type" can be "Posting" or "Active". This 
 
 ```Signature.signBufferSha256(hash.sha256(message), wif).toHex();```
 
+You can also pass in a JSON-stringified Node.js Buffer object. For example, if `buffer` is a Node.js Buffer
+to be signed, you can pass `JSON.stringify(buffer)` as `message`, then this method becomes equivalent to
+
+```Signature.signBufferSha256(hash.sha256(buffer), wif).toHex();```
+
 ### Broadcast
 
 Sites can request that the extension sign and broadcast general operations allowed by the `steem-js` library:

--- a/decode_wrapper/decode.min.js
+++ b/decode_wrapper/decode.min.js
@@ -1,14 +1,36 @@
 (function(){function r(e,n,t){function o(i,f){if(!n[i]){if(!e[i]){var c="function"==typeof require&&require;if(!f&&c)return c(i,!0);if(u)return u(i,!0);var a=new Error("Cannot find module '"+i+"'");throw a.code="MODULE_NOT_FOUND",a}var p=n[i]={exports:{}};e[i][0].call(p.exports,function(r){var n=e[i][1][r];return o(n||r)},p,p.exports,r,e,n,t)}return n[i].exports}for(var u="function"==typeof require&&require,i=0;i<t.length;i++)o(t[i]);return o}return r})()({1:[function(require,module,exports){
+(function (Buffer){
 var signature = require('steem/lib/auth/ecc');
 var steem = require('steem');
 
 
 window.decodeMemo = (e,r) => steem.memo.decode(e,r);
 window.encodeMemo = (e,r,a) => steem.memo.encode(e,r,a);
-window.signBuffer = (e,r) => signature.Signature.signBuffer(e,r).toHex();
+window.signBuffer = (e,r) => {
+    // try to parse Buffer
+    let buf = e;
+    try {
+        const o = JSON.parse(buf, (k, v) => {
+            if (v !== null
+                && typeof v === 'object'
+                && 'type' in v
+                && v.type === 'Buffer'
+                && 'data' in v
+                && Array.isArray(v.data)) {
+              return new Buffer(v.data);
+            }
+            return v;
+        });
+        if (Buffer.isBuffer(o)) {
+          buf = o;
+        }
+    } catch (e) {}
+    return signature.Signature.signBuffer(buf,r).toHex();
+}
 window.signedCall = (m,p,a,k,c) => steem.api.signedCall(m,p,a,k,c);
 
-},{"steem":178,"steem/lib/auth/ecc":148}],2:[function(require,module,exports){
+}).call(this,require("buffer").Buffer)
+},{"buffer":233,"steem":181,"steem/lib/auth/ecc":151}],2:[function(require,module,exports){
 /* global self */
 (function(root, factory) {
   if (typeof exports === 'object' && typeof exports.nodeName !== 'string') {
@@ -66,7 +88,7 @@ var sjcl = {
    * @namespace
    */
   keyexchange: {},
-
+  
   /**
    * Cipher modes of operation.
    * @namespace
@@ -78,7 +100,7 @@ var sjcl = {
    * @namespace
    */
   misc: {},
-
+  
   /**
    * Bit array encoders and decoders.
    * @namespace
@@ -90,7 +112,7 @@ var sjcl = {
    * the method names are "fromBits" and "toBits".
    */
   codec: {},
-
+  
   /**
    * Exceptions.
    * @namespace
@@ -104,7 +126,7 @@ var sjcl = {
       this.toString = function() { return "CORRUPT: "+this.message; };
       this.message = message;
     },
-
+    
     /**
      * Invalid parameter.
      * @constructor
@@ -113,7 +135,7 @@ var sjcl = {
       this.toString = function() { return "INVALID: "+this.message; };
       this.message = message;
     },
-
+    
     /**
      * Bug or missing feature in SJCL.
      * @constructor
@@ -209,7 +231,7 @@ sjcl.bitArray = {
     if (a1.length === 0 || a2.length === 0) {
       return a1.concat(a2);
     }
-
+    
     var last = a1[a1.length-1], shift = sjcl.bitArray.getPartial(last);
     if (shift === 32) {
       return a1.concat(a2);
@@ -295,7 +317,7 @@ sjcl.bitArray = {
   _shiftRight: function (a, shift, carry, out) {
     var i, last2=0, shift2;
     if (out === undefined) { out = []; }
-
+    
     for (; shift >= 32; shift -= 32) {
       out.push(carry);
       carry = 0;
@@ -303,7 +325,7 @@ sjcl.bitArray = {
     if (shift === 0) {
       return out.concat(a);
     }
-
+    
     for (i=0; i<a.length; i++) {
       out.push(carry | a[i]>>>shift);
       carry = a[i] << (32-shift);
@@ -313,7 +335,7 @@ sjcl.bitArray = {
     out.push(sjcl.bitArray.partial(shift+shift2 & 31, (shift + shift2 > 32) ? carry : out.pop(),1));
     return out;
   },
-
+  
   /** xor a block of 4 words together.
    * @private
    */
@@ -363,36 +385,36 @@ sjcl.cipher.aes = function (key) {
   if (!this._tables[0][0][0]) {
     this._precompute();
   }
-
+  
   var i, j, tmp,
     encKey, decKey,
     sbox = this._tables[0][4], decTable = this._tables[1],
     keyLen = key.length, rcon = 1;
-
+  
   if (keyLen !== 4 && keyLen !== 6 && keyLen !== 8) {
     throw new sjcl.exception.invalid("invalid aes key size");
   }
-
+  
   this._key = [encKey = key.slice(0), decKey = []];
-
+  
   // schedule encryption keys
   for (i = keyLen; i < 4 * keyLen + 28; i++) {
     tmp = encKey[i-1];
-
+    
     // apply sbox
     if (i%keyLen === 0 || (keyLen === 8 && i%keyLen === 4)) {
       tmp = sbox[tmp>>>24]<<24 ^ sbox[tmp>>16&255]<<16 ^ sbox[tmp>>8&255]<<8 ^ sbox[tmp&255];
-
+      
       // shift rows and add rcon
       if (i%keyLen === 0) {
         tmp = tmp<<8 ^ tmp>>>24 ^ rcon<<24;
         rcon = rcon<<1 ^ (rcon>>7)*283;
       }
     }
-
+    
     encKey[i] = encKey[i-keyLen] ^ tmp;
   }
-
+  
   // schedule decryption keys
   for (j = 0; i; j++, i--) {
     tmp = encKey[j&3 ? i : i - 4];
@@ -414,21 +436,21 @@ sjcl.cipher.aes.prototype = {
   blockSize: 4,
   keySizes: [4,6,8],
   */
-
+  
   /**
    * Encrypt an array of 4 big-endian words.
    * @param {Array} data The plaintext.
    * @return {Array} The ciphertext.
    */
   encrypt:function (data) { return this._crypt(data,0); },
-
+  
   /**
    * Decrypt an array of 4 big-endian words.
    * @param {Array} data The ciphertext.
    * @return {Array} The plaintext.
    */
   decrypt:function (data) { return this._crypt(data,1); },
-
+  
   /**
    * The expanded S-box and inverse S-box tables.  These will be computed
    * on the client so that we don't have to send them down the wire.
@@ -457,32 +479,32 @@ sjcl.cipher.aes.prototype = {
    for (i = 0; i < 256; i++) {
      th[( d[i] = i<<1 ^ (i>>7)*283 )^i]=i;
    }
-
+   
    for (x = xInv = 0; !sbox[x]; x ^= x2 || 1, xInv = th[xInv] || 1) {
      // Compute sbox
      s = xInv ^ xInv<<1 ^ xInv<<2 ^ xInv<<3 ^ xInv<<4;
      s = s>>8 ^ s&255 ^ 99;
      sbox[x] = s;
      sboxInv[s] = x;
-
+     
      // Compute MixColumns
      x8 = d[x4 = d[x2 = d[x]]];
      tDec = x8*0x1010101 ^ x4*0x10001 ^ x2*0x101 ^ x*0x1010100;
      tEnc = d[s]*0x101 ^ s*0x1010100;
-
+     
      for (i = 0; i < 4; i++) {
        encTable[i][x] = tEnc = tEnc<<24 ^ tEnc>>>8;
        decTable[i][s] = tDec = tDec<<24 ^ tDec>>>8;
      }
    }
-
+   
    // Compactify.  Considerable speedup on Firefox.
    for (i = 0; i < 5; i++) {
      encTable[i] = encTable[i].slice(0);
      decTable[i] = decTable[i].slice(0);
    }
   },
-
+  
   /**
    * Encryption and decryption core.
    * @param {Array} input Four words to be encrypted or decrypted.
@@ -494,7 +516,7 @@ sjcl.cipher.aes.prototype = {
     if (input.length !== 4) {
       throw new sjcl.exception.invalid("invalid aes block size");
     }
-
+    
     var key = this._key[dir],
         // state variables a,b,c,d are loaded with pre-whitened data
         a = input[0]           ^ key[0],
@@ -502,20 +524,20 @@ sjcl.cipher.aes.prototype = {
         c = input[2]           ^ key[2],
         d = input[dir ? 1 : 3] ^ key[3],
         a2, b2, c2,
-
+        
         nInnerRounds = key.length/4 - 2,
         i,
         kIndex = 4,
         out = [0,0,0,0],
         table = this._tables[dir],
-
+        
         // load up the tables
         t0    = table[0],
         t1    = table[1],
         t2    = table[2],
         t3    = table[3],
         sbox  = table[4];
-
+ 
     // Inner rounds.  Cribbed from OpenSSL.
     for (i = 0; i < nInnerRounds; i++) {
       a2 = t0[a>>>24] ^ t1[b>>16 & 255] ^ t2[c>>8 & 255] ^ t3[d & 255] ^ key[kIndex];
@@ -525,18 +547,18 @@ sjcl.cipher.aes.prototype = {
       kIndex += 4;
       a=a2; b=b2; c=c2;
     }
-
+        
     // Last round.
     for (i = 0; i < 4; i++) {
       out[dir ? 3&-i : i] =
-        sbox[a>>>24      ]<<24 ^
+        sbox[a>>>24      ]<<24 ^ 
         sbox[b>>16  & 255]<<16 ^
         sbox[c>>8   & 255]<<8  ^
         sbox[d      & 255]     ^
         key[kIndex++];
       a2=a; a=b; b=c; c=d; d=a2;
     }
-
+    
     return out;
   }
 };
@@ -1294,7 +1316,7 @@ if (typeof(ArrayBuffer) === 'undefined') {
  * @namespace
  */
 sjcl.codec.arrayBuffer = {
-  /** Convert from a bitArray to an ArrayBuffer.
+  /** Convert from a bitArray to an ArrayBuffer. 
    * Will default to 8byte padding if padding is undefined*/
   fromBits: function (arr, padding, padding_count) {
     var out, i, ol, tmp, smallest;
@@ -1307,7 +1329,7 @@ sjcl.codec.arrayBuffer = {
 
     ol = sjcl.bitArray.bitLength(arr)/8;
 
-    //check to make sure the bitLength is divisible by 8, if it isn't
+    //check to make sure the bitLength is divisible by 8, if it isn't 
     //we can't do anything since arraybuffers work with bytes, not bits
     if ( sjcl.bitArray.bitLength(arr)%8 !== 0 ) {
       throw new sjcl.exception.invalid("Invalid bit size, must be divisble by 8 to fit in an arraybuffer correctly");
@@ -1359,11 +1381,11 @@ sjcl.codec.arrayBuffer = {
       tmp = new DataView(new ArrayBuffer(4));
       for (var i = 0, l = inView.byteLength%4; i < l; i++) {
         //we want the data to the right, because partial slices off the starting bits
-        tmp.setUint8(i+4-l, inView.getUint8(len+i)); // big-endian,
+        tmp.setUint8(i+4-l, inView.getUint8(len+i)); // big-endian, 
       }
       out.push(
         sjcl.bitArray.partial( (inView.byteLength%4)*8, tmp.getUint32(0) )
-      );
+      ); 
     }
     return out;
   },
@@ -1748,7 +1770,7 @@ sjcl.ecc.curves = {
     "0xb3312fa7e23ee7e4988e056be3f82d19181d9c6efe8141120314088f5013875ac656398d8a2ed19d2a85c8edd3ec2aef",
     "0xaa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab7",
     "0x3617de4a96262c6f5d9e98bf9292dc29f8f41dbd289a147ce9da3113b5f0b8c00a60b1ce1d7e819d7a431d7c90ea0e5f"),
-
+    
   c521: new sjcl.ecc.curve(
     sjcl.bn.prime.p521,
     "0x1FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA51868783BF2F966B7FCC0148F709A5D03BB5C9B8899C47AEBB6FB71E91386409",
@@ -1810,7 +1832,7 @@ sjcl.ecc.deserialize = function (key) {
     return new sjcl.ecc[key.type].secretKey(curve, exponent);
   } else {
     if (!key.point) { throw new sjcl.exception.invalid("invalid point"); }
-
+    
     var point = curve.fromBits(sjcl.codec.hex.toBits(key.point));
     return new sjcl.ecc[key.type].publicKey(curve, point);
   }
@@ -1940,7 +1962,7 @@ sjcl.ecc.elGamal.publicKey.prototype = {
         key = sjcl.hash.sha256.hash(this._point.mult(sec).toBits());
     return { key: key, tag: tag };
   },
-
+  
   getType: function() {
     return "elGamal";
   }
@@ -1970,7 +1992,7 @@ sjcl.ecc.elGamal.secretKey.prototype = {
   */
   dhJavaEc: function(pk) {
     return pk._point.mult(this._exponent).x.toBits();
-  },
+  }, 
 
   getType: function() {
     return "elGamal";
@@ -2319,7 +2341,7 @@ sjcl.hash.sha256.prototype = {
    * @constant
    */
   blockSize: 512,
-
+   
   /**
    * Reset the hash state.
    * @return this
@@ -2330,7 +2352,7 @@ sjcl.hash.sha256.prototype = {
     this._length = 0;
     return this;
   },
-
+  
   /**
    * Input several words to the hash.
    * @param {bitArray|String} data the data to hash.
@@ -2362,7 +2384,7 @@ sjcl.hash.sha256.prototype = {
     }
     return this;
   },
-
+  
   /**
    * Complete hashing and output the hash value.
    * @return {bitArray} The hash value, an array of 8 big-endian words.
@@ -2372,12 +2394,12 @@ sjcl.hash.sha256.prototype = {
 
     // Round out and push the buffer
     b = sjcl.bitArray.concat(b, [sjcl.bitArray.partial(1,1)]);
-
+    
     // Round out the buffer to a multiple of 16 words, less the 2 length words.
     for (i = b.length + 2; i & 15; i++) {
       b.push(0);
     }
-
+    
     // append the length
     b.push(Math.floor(this._length / 0x100000000));
     b.push(this._length | 0);
@@ -2398,7 +2420,7 @@ sjcl.hash.sha256.prototype = {
   /*
   _init:[0x6a09e667,0xbb67ae85,0x3c6ef372,0xa54ff53a,0x510e527f,0x9b05688c,0x1f83d9ab,0x5be0cd19],
   */
-
+  
   /**
    * The SHA-256 hash key, to be precomputed.
    * @private
@@ -2443,13 +2465,13 @@ sjcl.hash.sha256.prototype = {
       }
     }
   },
-
+  
   /**
    * Perform one cycle of SHA-256.
    * @param {Uint32Array|bitArray} w one block of words.
    * @private
    */
-  _block:function (w) {
+  _block:function (w) {  
     var i, tmp, a, b,
       h = this._h,
       k = this._key,
@@ -2476,13 +2498,13 @@ sjcl.hash.sha256.prototype = {
       } else {
         a   = w[(i+1 ) & 15];
         b   = w[(i+14) & 15];
-        tmp = w[i&15] = ((a>>>7  ^ a>>>18 ^ a>>>3  ^ a<<25 ^ a<<14) +
+        tmp = w[i&15] = ((a>>>7  ^ a>>>18 ^ a>>>3  ^ a<<25 ^ a<<14) + 
                          (b>>>17 ^ b>>>19 ^ b>>>10 ^ b<<15 ^ b<<13) +
                          w[i&15] + w[(i+9) & 15]) | 0;
       }
-
+      
       tmp = (tmp + h7 + (h4>>>6 ^ h4>>>11 ^ h4>>>25 ^ h4<<26 ^ h4<<21 ^ h4<<7) +  (h6 ^ h4&(h5^h6)) + k[i]); // | 0;
-
+      
       // shift register
       h7 = h6; h6 = h5; h5 = h4;
       h4 = h3 + tmp | 0;
@@ -2512,7 +2534,7 @@ sjcl.hash.sha256.prototype = {
  * @author Steve Thomas
  */
 
-/**
+/** 
  * @class Random number generator
  * @description
  * <b>Use sjcl.random as a singleton for this class!</b>
@@ -2549,17 +2571,17 @@ sjcl.hash.sha256.prototype = {
  * @constructor
  */
 sjcl.prng = function(defaultParanoia) {
-
+  
   /* private */
   this._pools                   = [new sjcl.hash.sha256()];
   this._poolEntropy             = [0];
   this._reseedCount             = 0;
   this._robins                  = {};
   this._eventId                 = 0;
-
+  
   this._collectorIds            = {};
   this._collectorIdNext         = 0;
-
+  
   this._strength                = 0;
   this._poolStrength            = 0;
   this._nextReseed              = 0;
@@ -2567,12 +2589,12 @@ sjcl.prng = function(defaultParanoia) {
   this._counter                 = [0,0,0,0];
   this._cipher                  = undefined;
   this._defaultParanoia         = defaultParanoia;
-
+  
   /* event listener stuff */
   this._collectorsStarted       = false;
   this._callbacks               = {progress: {}, seeded: {}};
   this._callbackI               = 0;
-
+  
   /* constants */
   this._NOT_READY               = 0;
   this._READY                   = 1;
@@ -2583,7 +2605,7 @@ sjcl.prng = function(defaultParanoia) {
   this._MILLISECONDS_PER_RESEED = 30000;
   this._BITS_PER_RESEED         = 80;
 };
-
+ 
 sjcl.prng.prototype = {
   /** Generate several random words, and return them in an array.
    * A word consists of 32 bits (4 bytes)
@@ -2591,26 +2613,26 @@ sjcl.prng.prototype = {
    */
   randomWords: function (nwords, paranoia) {
     var out = [], i, readiness = this.isReady(paranoia), g;
-
+  
     if (readiness === this._NOT_READY) {
       throw new sjcl.exception.notReady("generator isn't seeded");
     } else if (readiness & this._REQUIRES_RESEED) {
       this._reseedFromPools(!(readiness & this._READY));
     }
-
+  
     for (i=0; i<nwords; i+= 4) {
       if ((i+1) % this._MAX_WORDS_PER_BURST === 0) {
         this._gate();
       }
-
+   
       g = this._gen4words();
       out.push(g[0],g[1],g[2],g[3]);
     }
     this._gate();
-
+  
     return out.slice(0,nwords);
   },
-
+  
   setDefaultParanoia: function (paranoia, allowZeroParanoia) {
     if (paranoia === 0 && allowZeroParanoia !== "Setting paranoia=0 will ruin your security; use it only for testing") {
       throw new sjcl.exception.invalid("Setting paranoia=0 will ruin your security; use it only for testing");
@@ -2618,7 +2640,7 @@ sjcl.prng.prototype = {
 
     this._defaultParanoia = paranoia;
   },
-
+  
   /**
    * Add entropy to the pools.
    * @param data The entropic value.  Should be a 32-bit integer, array of 32-bit integers, or string
@@ -2627,28 +2649,28 @@ sjcl.prng.prototype = {
    */
   addEntropy: function (data, estimatedEntropy, source) {
     source = source || "user";
-
+  
     var id,
       i, tmp,
       t = (new Date()).valueOf(),
       robin = this._robins[source],
       oldReady = this.isReady(), err = 0, objName;
-
+      
     id = this._collectorIds[source];
     if (id === undefined) { id = this._collectorIds[source] = this._collectorIdNext ++; }
-
+      
     if (robin === undefined) { robin = this._robins[source] = 0; }
     this._robins[source] = ( this._robins[source] + 1 ) % this._pools.length;
-
+  
     switch(typeof(data)) {
-
+      
     case "number":
       if (estimatedEntropy === undefined) {
         estimatedEntropy = 1;
       }
       this._pools[robin].update([id,this._eventId++,1,estimatedEntropy,t,1,data|0]);
       break;
-
+      
     case "object":
       objName = Object.prototype.toString.call(data);
       if (objName === "[object Uint32Array]") {
@@ -2682,7 +2704,7 @@ sjcl.prng.prototype = {
         this._pools[robin].update([id,this._eventId++,2,estimatedEntropy,t,data.length].concat(data));
       }
       break;
-
+      
     case "string":
       if (estimatedEntropy === undefined) {
        /* English text has just over 1 bit per character of entropy.
@@ -2694,18 +2716,18 @@ sjcl.prng.prototype = {
       this._pools[robin].update([id,this._eventId++,3,estimatedEntropy,t,data.length]);
       this._pools[robin].update(data);
       break;
-
+      
     default:
       err=1;
     }
     if (err) {
       throw new sjcl.exception.bug("random: addEntropy only supports number, array of numbers or string");
     }
-
+  
     /* record the new strength */
     this._poolEntropy[robin] += estimatedEntropy;
     this._poolStrength += estimatedEntropy;
-
+  
     /* fire off events */
     if (oldReady === this._NOT_READY) {
       if (this.isReady() !== this._NOT_READY) {
@@ -2714,11 +2736,11 @@ sjcl.prng.prototype = {
       this._fireEvent("progress", this.getProgress());
     }
   },
-
+  
   /** Is the generator ready? */
   isReady: function (paranoia) {
     var entropyRequired = this._PARANOIA_LEVELS[ (paranoia !== undefined) ? paranoia : this._defaultParanoia ];
-
+  
     if (this._strength && this._strength >= entropyRequired) {
       return (this._poolEntropy[0] > this._BITS_PER_RESEED && (new Date()).valueOf() > this._nextReseed) ?
         this._REQUIRES_RESEED | this._READY :
@@ -2729,11 +2751,11 @@ sjcl.prng.prototype = {
         this._NOT_READY;
     }
   },
-
+  
   /** Get the generator's progress toward readiness, as a fraction */
   getProgress: function (paranoia) {
     var entropyRequired = this._PARANOIA_LEVELS[ paranoia ? paranoia : this._defaultParanoia ];
-
+  
     if (this._strength >= entropyRequired) {
       return 1.0;
     } else {
@@ -2742,11 +2764,11 @@ sjcl.prng.prototype = {
         this._poolStrength / entropyRequired;
     }
   },
-
+  
   /** start the built-in entropy collectors */
   startCollectors: function () {
     if (this._collectorsStarted) { return; }
-
+  
     this._eventListener = {
       loadTimeCollector: this._bind(this._loadTimeCollector),
       mouseCollector: this._bind(this._mouseCollector),
@@ -2768,14 +2790,14 @@ sjcl.prng.prototype = {
     } else {
       throw new sjcl.exception.bug("can't attach event");
     }
-
+  
     this._collectorsStarted = true;
   },
-
+  
   /** stop the built-in entropy collectors */
   stopCollectors: function () {
     if (!this._collectorsStarted) { return; }
-
+  
     if (window.removeEventListener) {
       window.removeEventListener("load", this._eventListener.loadTimeCollector, false);
       window.removeEventListener("mousemove", this._eventListener.mouseCollector, false);
@@ -2790,17 +2812,17 @@ sjcl.prng.prototype = {
 
     this._collectorsStarted = false;
   },
-
+  
   /* use a cookie to store entropy.
   useCookie: function (all_cookies) {
       throw new sjcl.exception.bug("random: useCookie is unimplemented");
   },*/
-
+  
   /** add an event listener for progress or seeded-ness. */
   addEventListener: function (name, callback) {
     this._callbacks[name][this._callbackI++] = callback;
   },
-
+  
   /** remove an event listener for progress or seeded-ness */
   removeEventListener: function (name, cb) {
     var i, j, cbs=this._callbacks[name], jsTemp=[];
@@ -2820,7 +2842,7 @@ sjcl.prng.prototype = {
       delete cbs[j];
     }
   },
-
+  
   _bind: function (func) {
     var that = this;
     return function () {
@@ -2838,7 +2860,7 @@ sjcl.prng.prototype = {
     }
     return this._cipher.encrypt(this._counter);
   },
-
+  
   /* Rekey the AES instance with itself after a request, or every _MAX_WORDS_PER_BURST words.
    * @private
    */
@@ -2846,7 +2868,7 @@ sjcl.prng.prototype = {
     this._key = this._gen4words().concat(this._gen4words());
     this._cipher = new sjcl.cipher.aes(this._key);
   },
-
+  
   /** Reseed the generator with the given words
    * @private
    */
@@ -2858,51 +2880,51 @@ sjcl.prng.prototype = {
       if (this._counter[i]) { break; }
     }
   },
-
+  
   /** reseed the data from the entropy pools
    * @param full If set, use all the entropy pools in the reseed.
    */
   _reseedFromPools: function (full) {
     var reseedData = [], strength = 0, i;
-
+  
     this._nextReseed = reseedData[0] =
       (new Date()).valueOf() + this._MILLISECONDS_PER_RESEED;
-
+    
     for (i=0; i<16; i++) {
       /* On some browsers, this is cryptographically random.  So we might
        * as well toss it in the pot and stir...
        */
       reseedData.push(Math.random()*0x100000000|0);
     }
-
+    
     for (i=0; i<this._pools.length; i++) {
      reseedData = reseedData.concat(this._pools[i].finalize());
      strength += this._poolEntropy[i];
      this._poolEntropy[i] = 0;
-
+   
      if (!full && (this._reseedCount & (1<<i))) { break; }
     }
-
+  
     /* if we used the last pool, push a new one onto the stack */
     if (this._reseedCount >= 1 << this._pools.length) {
      this._pools.push(new sjcl.hash.sha256());
      this._poolEntropy.push(0);
     }
-
+  
     /* how strong was this reseed? */
     this._poolStrength -= strength;
     if (strength > this._strength) {
       this._strength = strength;
     }
-
+  
     this._reseedCount ++;
     this._reseed(reseedData);
   },
-
+  
   _keyboardCollector: function () {
     this._addCurrentTimeToEntropy(1);
   },
-
+  
   _mouseCollector: function (ev) {
     var x, y;
 
@@ -2931,7 +2953,7 @@ sjcl.prng.prototype = {
 
     this._addCurrentTimeToEntropy(0);
   },
-
+  
   _loadTimeCollector: function () {
     this._addCurrentTimeToEntropy(2);
   },
@@ -3258,7 +3280,7 @@ sjcl.codec.steemit = {
       if (fixedKForTesting) {
         fixedKForTesting = fixedKForTesting.add(1);
       }
-
+      
       if (R.isIdentity) {
         continue;
       }
@@ -3272,7 +3294,7 @@ sjcl.codec.steemit = {
         if (isOdd) {
           recoveryParam++;
         }
-
+   
         var rBitArray = r.toBits(l);
         var sBitArray = s.toBits(l);
 
@@ -3280,13 +3302,13 @@ sjcl.codec.steemit = {
         var r1 = sjcl.bitArray.extract(rBitArray, 8, 8);
         var s0 = sjcl.bitArray.extract(sBitArray, 0, 8);
         var s1 = sjcl.bitArray.extract(sBitArray, 8, 8);
-
+            
         if (!(r0 & 0x80)
           && !(r0 == 0 && !(r1 & 0x80))
           && !(s0 & 0x80)
           && !(s0 == 0 && !(s1 & 0x80))) {
           var rawSig = sjcl.bitArray.concat(r.toBits(l), s.toBits(l));
-
+      
           return sjcl.bitArray.concat(
             [sjcl.bitArray.partial(8, recoveryParam)],
             rawSig
@@ -3562,7 +3584,7 @@ sjcl.codec.steemit = {
   }
 });
 
-},{"crypto":235}],3:[function(require,module,exports){
+},{"crypto":241}],3:[function(require,module,exports){
 (function (Buffer){
 "use strict";
 /**
@@ -3763,7 +3785,7 @@ function validate(request, verify) {
 exports.validate = validate;
 
 }).call(this,require("buffer").Buffer)
-},{"@steemit/libcrypto":2,"buffer":227,"crypto":235}],4:[function(require,module,exports){
+},{"@steemit/libcrypto":2,"buffer":233,"crypto":241}],4:[function(require,module,exports){
 // base-x encoding / decoding
 // Copyright (c) 2018 base-x contributors
 // Copyright (c) 2014-2018 The Bitcoin Core developers (base58.cpp)
@@ -3915,7 +3937,7 @@ module.exports = function base (ALPHABET) {
   }
 }
 
-},{"safe-buffer":131}],5:[function(require,module,exports){
+},{"safe-buffer":134}],5:[function(require,module,exports){
 // (public) Constructor
 function BigInteger(a, b, c) {
   if (!(this instanceof BigInteger))
@@ -5521,7 +5543,7 @@ BigInteger.prototype.toHex = function(size) {
 }
 
 }).call(this,require("buffer").Buffer)
-},{"./bigi":5,"assert":194,"buffer":227}],7:[function(require,module,exports){
+},{"./bigi":5,"assert":197,"buffer":233}],7:[function(require,module,exports){
 var BigInteger = require('./bigi')
 
 //addons
@@ -5553,7 +5575,7 @@ module.exports={
   "_resolved": "https://registry.npmjs.org/bigi/-/bigi-1.4.2.tgz",
   "_shasum": "9c665a95f88b8b08fc05cfd731f561859d725825",
   "_spec": "bigi@^1.4.2",
-  "_where": "/home/quentin/Documents/projects/steem-wallet/decode_wrapper/node_modules/steem",
+  "_where": "/home/eonwarped/steem-keychain-master/decode_wrapper/node_modules/steem",
   "bugs": {
     "url": "https://github.com/cryptocoinjs/bigi/issues"
   },
@@ -5616,22 +5638,22 @@ module.exports={
 }
 
 },{}],9:[function(require,module,exports){
-(function (process,global){
+(function (process,global,setImmediate){
 /* @preserve
  * The MIT License (MIT)
- *
+ * 
  * Copyright (c) 2013-2018 Petka Antonov
- *
+ * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- *
+ * 
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- *
+ * 
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
@@ -5639,7 +5661,7 @@ module.exports={
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
- *
+ * 
  */
 /**
  * bluebird build version 3.5.3
@@ -9154,28 +9176,28 @@ _dereq_('./some.js')(Promise, PromiseArray, apiRejection);
 _dereq_('./filter.js')(Promise, INTERNAL);
 _dereq_('./each.js')(Promise, INTERNAL);
 _dereq_('./any.js')(Promise);
-
-    util.toFastProperties(Promise);
-    util.toFastProperties(Promise.prototype);
-    function fillTypes(value) {
-        var p = new Promise(INTERNAL);
-        p._fulfillmentHandler0 = value;
-        p._rejectionHandler0 = value;
-        p._promise0 = value;
-        p._receiver0 = value;
-    }
-    // Complete slack tracking, opt out of field-type tracking and
-    // stabilize map
-    fillTypes({a: 1});
-    fillTypes({b: 2});
-    fillTypes({c: 3});
-    fillTypes(1);
-    fillTypes(function(){});
-    fillTypes(undefined);
-    fillTypes(false);
-    fillTypes(new Promise(INTERNAL));
-    debug.setBounds(Async.firstLineError, util.lastLineError);
-    return Promise;
+                                                         
+    util.toFastProperties(Promise);                                          
+    util.toFastProperties(Promise.prototype);                                
+    function fillTypes(value) {                                              
+        var p = new Promise(INTERNAL);                                       
+        p._fulfillmentHandler0 = value;                                      
+        p._rejectionHandler0 = value;                                        
+        p._promise0 = value;                                                 
+        p._receiver0 = value;                                                
+    }                                                                        
+    // Complete slack tracking, opt out of field-type tracking and           
+    // stabilize map                                                         
+    fillTypes({a: 1});                                                       
+    fillTypes({b: 2});                                                       
+    fillTypes({c: 3});                                                       
+    fillTypes(1);                                                            
+    fillTypes(function(){});                                                 
+    fillTypes(undefined);                                                    
+    fillTypes(false);                                                        
+    fillTypes(new Promise(INTERNAL));                                        
+    debug.setBounds(Async.firstLineError, util.lastLineError);               
+    return Promise;                                                          
 
 };
 
@@ -9963,8 +9985,8 @@ function ReductionPromiseArray(promises, fn, initialValue, _each) {
 util.inherits(ReductionPromiseArray, PromiseArray);
 
 ReductionPromiseArray.prototype._gotAccum = function(accum) {
-    if (this._eachValues !== undefined &&
-        this._eachValues !== null &&
+    if (this._eachValues !== undefined && 
+        this._eachValues !== null && 
         accum !== INTERNAL) {
         this._eachValues.push(accum);
     }
@@ -11264,8 +11286,8 @@ module.exports = ret;
 
 },{"./es5":13}]},{},[4])(4)
 });                    ;if (typeof window !== 'undefined' && window !== null) {                               window.P = window.Promise;                                                     } else if (typeof self !== 'undefined' && self !== null) {                             self.P = self.Promise;                                                         }
-}).call(this,require('_process'),typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"_process":297}],10:[function(require,module,exports){
+}).call(this,require('_process'),typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {},require("timers").setImmediate)
+},{"_process":303,"timers":337}],10:[function(require,module,exports){
 // based on the aes implimentation in triple sec
 // https://github.com/keybase/triplesec
 // which is in turn based on the one from crypto-js
@@ -11495,7 +11517,7 @@ AES.prototype.scrub = function () {
 
 module.exports.AES = AES
 
-},{"safe-buffer":131}],11:[function(require,module,exports){
+},{"safe-buffer":134}],11:[function(require,module,exports){
 var aes = require('./aes')
 var Buffer = require('safe-buffer').Buffer
 var Transform = require('cipher-base')
@@ -11614,7 +11636,7 @@ StreamCipher.prototype.setAAD = function setAAD (buf) {
 
 module.exports = StreamCipher
 
-},{"./aes":10,"./ghash":15,"./incr32":16,"buffer-xor":28,"cipher-base":30,"inherits":46,"safe-buffer":131}],12:[function(require,module,exports){
+},{"./aes":10,"./ghash":15,"./incr32":16,"buffer-xor":28,"cipher-base":30,"inherits":46,"safe-buffer":134}],12:[function(require,module,exports){
 var ciphers = require('./encrypter')
 var deciphers = require('./decrypter')
 var modes = require('./modes/list.json')
@@ -11755,7 +11777,7 @@ function createDecipher (suite, password) {
 exports.createDecipher = createDecipher
 exports.createDecipheriv = createDecipheriv
 
-},{"./aes":10,"./authCipher":11,"./modes":23,"./streamCipher":26,"cipher-base":30,"evp_bytestokey":44,"inherits":46,"safe-buffer":131}],14:[function(require,module,exports){
+},{"./aes":10,"./authCipher":11,"./modes":23,"./streamCipher":26,"cipher-base":30,"evp_bytestokey":44,"inherits":46,"safe-buffer":134}],14:[function(require,module,exports){
 var MODES = require('./modes')
 var AuthCipher = require('./authCipher')
 var Buffer = require('safe-buffer').Buffer
@@ -11871,7 +11893,7 @@ function createCipher (suite, password) {
 exports.createCipheriv = createCipheriv
 exports.createCipher = createCipher
 
-},{"./aes":10,"./authCipher":11,"./modes":23,"./streamCipher":26,"cipher-base":30,"evp_bytestokey":44,"inherits":46,"safe-buffer":131}],15:[function(require,module,exports){
+},{"./aes":10,"./authCipher":11,"./modes":23,"./streamCipher":26,"cipher-base":30,"evp_bytestokey":44,"inherits":46,"safe-buffer":134}],15:[function(require,module,exports){
 var Buffer = require('safe-buffer').Buffer
 var ZEROES = Buffer.alloc(16, 0)
 
@@ -11962,7 +11984,7 @@ GHASH.prototype.final = function (abl, bl) {
 
 module.exports = GHASH
 
-},{"safe-buffer":131}],16:[function(require,module,exports){
+},{"safe-buffer":134}],16:[function(require,module,exports){
 function incr32 (iv) {
   var len = iv.length
   var item
@@ -12033,7 +12055,7 @@ exports.encrypt = function (self, data, decrypt) {
   return out
 }
 
-},{"buffer-xor":28,"safe-buffer":131}],19:[function(require,module,exports){
+},{"buffer-xor":28,"safe-buffer":134}],19:[function(require,module,exports){
 var Buffer = require('safe-buffer').Buffer
 
 function encryptByte (self, byteParam, decrypt) {
@@ -12077,7 +12099,7 @@ exports.encrypt = function (self, chunk, decrypt) {
   return out
 }
 
-},{"safe-buffer":131}],20:[function(require,module,exports){
+},{"safe-buffer":134}],20:[function(require,module,exports){
 var Buffer = require('safe-buffer').Buffer
 
 function encryptByte (self, byteParam, decrypt) {
@@ -12104,7 +12126,7 @@ exports.encrypt = function (self, chunk, decrypt) {
   return out
 }
 
-},{"safe-buffer":131}],21:[function(require,module,exports){
+},{"safe-buffer":134}],21:[function(require,module,exports){
 var xor = require('buffer-xor')
 var Buffer = require('safe-buffer').Buffer
 var incr32 = require('../incr32')
@@ -12136,7 +12158,7 @@ exports.encrypt = function (self, chunk) {
   return xor(chunk, pad)
 }
 
-},{"../incr32":16,"buffer-xor":28,"safe-buffer":131}],22:[function(require,module,exports){
+},{"../incr32":16,"buffer-xor":28,"safe-buffer":134}],22:[function(require,module,exports){
 exports.encrypt = function (self, block) {
   return self._cipher.encryptBlock(block)
 }
@@ -12378,7 +12400,7 @@ exports.encrypt = function (self, chunk) {
 }
 
 }).call(this,require("buffer").Buffer)
-},{"buffer":227,"buffer-xor":28}],26:[function(require,module,exports){
+},{"buffer":233,"buffer-xor":28}],26:[function(require,module,exports){
 var aes = require('./aes')
 var Buffer = require('safe-buffer').Buffer
 var Transform = require('cipher-base')
@@ -12407,7 +12429,7 @@ StreamCipher.prototype._final = function () {
 
 module.exports = StreamCipher
 
-},{"./aes":10,"cipher-base":30,"inherits":46,"safe-buffer":131}],27:[function(require,module,exports){
+},{"./aes":10,"cipher-base":30,"inherits":46,"safe-buffer":134}],27:[function(require,module,exports){
 var basex = require('base-x')
 var ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
 
@@ -12427,7 +12449,7 @@ module.exports = function xor (a, b) {
 }
 
 }).call(this,require("buffer").Buffer)
-},{"buffer":227}],29:[function(require,module,exports){
+},{"buffer":233}],29:[function(require,module,exports){
 /*
  Copyright 2013-2014 Daniel Wirtz <dcode@dcode.io>
 
@@ -16276,7 +16298,7 @@ CipherBase.prototype._toString = function (value, enc, fin) {
 
 module.exports = CipherBase
 
-},{"inherits":46,"safe-buffer":131,"stream":329,"string_decoder":330}],31:[function(require,module,exports){
+},{"inherits":46,"safe-buffer":134,"stream":335,"string_decoder":336}],31:[function(require,module,exports){
 'use strict'
 var inherits = require('inherits')
 var MD5 = require('md5.js')
@@ -16308,7 +16330,7 @@ module.exports = function createHash (alg) {
   return new Hash(sha(alg))
 }
 
-},{"cipher-base":30,"inherits":46,"md5.js":128,"ripemd160":130,"sha.js":134}],32:[function(require,module,exports){
+},{"cipher-base":30,"inherits":46,"md5.js":128,"ripemd160":133,"sha.js":137}],32:[function(require,module,exports){
 var MD5 = require('md5.js')
 
 module.exports = function (buffer) {
@@ -16379,7 +16401,7 @@ module.exports = function createHmac (alg, key) {
   return new Hmac(alg, key)
 }
 
-},{"./legacy":34,"cipher-base":30,"create-hash/md5":32,"inherits":46,"ripemd160":130,"safe-buffer":131,"sha.js":134}],34:[function(require,module,exports){
+},{"./legacy":34,"cipher-base":30,"create-hash/md5":32,"inherits":46,"ripemd160":133,"safe-buffer":134,"sha.js":137}],34:[function(require,module,exports){
 'use strict'
 var inherits = require('inherits')
 var Buffer = require('safe-buffer').Buffer
@@ -16427,7 +16449,7 @@ Hmac.prototype._final = function () {
 }
 module.exports = Hmac
 
-},{"cipher-base":30,"inherits":46,"safe-buffer":131}],35:[function(require,module,exports){
+},{"cipher-base":30,"inherits":46,"safe-buffer":134}],35:[function(require,module,exports){
 var self = {};
 (function(self) {
   'use strict';
@@ -16905,7 +16927,7 @@ var self = {};
 
       // fetch now can be imported as the default object
       module.exports = fetch;
-
+    
 
 },{}],36:[function(require,module,exports){
 (function (process){
@@ -17096,7 +17118,7 @@ function localstorage() {
 }
 
 }).call(this,require('_process'))
-},{"./debug":37,"_process":297}],37:[function(require,module,exports){
+},{"./debug":37,"_process":303}],37:[function(require,module,exports){
 
 /**
  * This is the common logic for both the Node.js and web browser
@@ -17383,7 +17405,7 @@ Curve.prototype.validate = function (Q) {
 
 module.exports = Curve
 
-},{"./point":43,"assert":194,"bigi":7}],40:[function(require,module,exports){
+},{"./point":43,"assert":197,"bigi":7}],40:[function(require,module,exports){
 module.exports={
   "secp128r1": {
     "p": "fffffffdffffffffffffffffffffffff",
@@ -17731,7 +17753,7 @@ Point.prototype.toString = function () {
 
 module.exports = Point
 
-},{"assert":194,"bigi":7,"safe-buffer":131}],44:[function(require,module,exports){
+},{"assert":197,"bigi":7,"safe-buffer":134}],44:[function(require,module,exports){
 var Buffer = require('safe-buffer').Buffer
 var MD5 = require('md5.js')
 
@@ -17778,7 +17800,7 @@ function EVP_BytesToKey (password, salt, keyBits, ivLen) {
 
 module.exports = EVP_BytesToKey
 
-},{"md5.js":128,"safe-buffer":131}],45:[function(require,module,exports){
+},{"md5.js":128,"safe-buffer":134}],45:[function(require,module,exports){
 'use strict'
 var Buffer = require('safe-buffer').Buffer
 var Transform = require('stream').Transform
@@ -17875,7 +17897,7 @@ HashBase.prototype._digest = function () {
 
 module.exports = HashBase
 
-},{"inherits":46,"safe-buffer":131,"stream":329}],46:[function(require,module,exports){
+},{"inherits":46,"safe-buffer":134,"stream":335}],46:[function(require,module,exports){
 if (typeof Object.create === 'function') {
   // implementation from standard node.js 'util' module
   module.exports = function inherits(ctor, superCtor) {
@@ -21378,7 +21400,7 @@ function fnI (a, b, c, d, m, k, s) {
 
 module.exports = MD5
 
-},{"hash-base":45,"inherits":46,"safe-buffer":131}],129:[function(require,module,exports){
+},{"hash-base":45,"inherits":46,"safe-buffer":134}],129:[function(require,module,exports){
 /**
  * Helpers.
  */
@@ -21533,6 +21555,270 @@ function plural(ms, n, name) {
 }
 
 },{}],130:[function(require,module,exports){
+module.exports = require('./lib/retry');
+},{"./lib/retry":131}],131:[function(require,module,exports){
+var RetryOperation = require('./retry_operation');
+
+exports.operation = function(options) {
+  var timeouts = exports.timeouts(options);
+  return new RetryOperation(timeouts, {
+      forever: options && options.forever,
+      unref: options && options.unref,
+      maxRetryTime: options && options.maxRetryTime
+  });
+};
+
+exports.timeouts = function(options) {
+  if (options instanceof Array) {
+    return [].concat(options);
+  }
+
+  var opts = {
+    retries: 10,
+    factor: 2,
+    minTimeout: 1 * 1000,
+    maxTimeout: Infinity,
+    randomize: false
+  };
+  for (var key in options) {
+    opts[key] = options[key];
+  }
+
+  if (opts.minTimeout > opts.maxTimeout) {
+    throw new Error('minTimeout is greater than maxTimeout');
+  }
+
+  var timeouts = [];
+  for (var i = 0; i < opts.retries; i++) {
+    timeouts.push(this.createTimeout(i, opts));
+  }
+
+  if (options && options.forever && !timeouts.length) {
+    timeouts.push(this.createTimeout(i, opts));
+  }
+
+  // sort the array numerically ascending
+  timeouts.sort(function(a,b) {
+    return a - b;
+  });
+
+  return timeouts;
+};
+
+exports.createTimeout = function(attempt, opts) {
+  var random = (opts.randomize)
+    ? (Math.random() + 1)
+    : 1;
+
+  var timeout = Math.round(random * opts.minTimeout * Math.pow(opts.factor, attempt));
+  timeout = Math.min(timeout, opts.maxTimeout);
+
+  return timeout;
+};
+
+exports.wrap = function(obj, options, methods) {
+  if (options instanceof Array) {
+    methods = options;
+    options = null;
+  }
+
+  if (!methods) {
+    methods = [];
+    for (var key in obj) {
+      if (typeof obj[key] === 'function') {
+        methods.push(key);
+      }
+    }
+  }
+
+  for (var i = 0; i < methods.length; i++) {
+    var method   = methods[i];
+    var original = obj[method];
+
+    obj[method] = function retryWrapper(original) {
+      var op       = exports.operation(options);
+      var args     = Array.prototype.slice.call(arguments, 1);
+      var callback = args.pop();
+
+      args.push(function(err) {
+        if (op.retry(err)) {
+          return;
+        }
+        if (err) {
+          arguments[0] = op.mainError();
+        }
+        callback.apply(this, arguments);
+      });
+
+      op.attempt(function() {
+        original.apply(obj, args);
+      });
+    }.bind(obj, original);
+    obj[method].options = options;
+  }
+};
+
+},{"./retry_operation":132}],132:[function(require,module,exports){
+function RetryOperation(timeouts, options) {
+  // Compatibility for the old (timeouts, retryForever) signature
+  if (typeof options === 'boolean') {
+    options = { forever: options };
+  }
+
+  this._originalTimeouts = JSON.parse(JSON.stringify(timeouts));
+  this._timeouts = timeouts;
+  this._options = options || {};
+  this._maxRetryTime = options && options.maxRetryTime || Infinity;
+  this._fn = null;
+  this._errors = [];
+  this._attempts = 1;
+  this._operationTimeout = null;
+  this._operationTimeoutCb = null;
+  this._timeout = null;
+  this._operationStart = null;
+
+  if (this._options.forever) {
+    this._cachedTimeouts = this._timeouts.slice(0);
+  }
+}
+module.exports = RetryOperation;
+
+RetryOperation.prototype.reset = function() {
+  this._attempts = 1;
+  this._timeouts = this._originalTimeouts;
+}
+
+RetryOperation.prototype.stop = function() {
+  if (this._timeout) {
+    clearTimeout(this._timeout);
+  }
+
+  this._timeouts       = [];
+  this._cachedTimeouts = null;
+};
+
+RetryOperation.prototype.retry = function(err) {
+  if (this._timeout) {
+    clearTimeout(this._timeout);
+  }
+
+  if (!err) {
+    return false;
+  }
+  var currentTime = new Date().getTime();
+  if (err && currentTime - this._operationStart >= this._maxRetryTime) {
+    this._errors.unshift(new Error('RetryOperation timeout occurred'));
+    return false;
+  }
+
+  this._errors.push(err);
+
+  var timeout = this._timeouts.shift();
+  if (timeout === undefined) {
+    if (this._cachedTimeouts) {
+      // retry forever, only keep last error
+      this._errors.splice(this._errors.length - 1, this._errors.length);
+      this._timeouts = this._cachedTimeouts.slice(0);
+      timeout = this._timeouts.shift();
+    } else {
+      return false;
+    }
+  }
+
+  var self = this;
+  var timer = setTimeout(function() {
+    self._attempts++;
+
+    if (self._operationTimeoutCb) {
+      self._timeout = setTimeout(function() {
+        self._operationTimeoutCb(self._attempts);
+      }, self._operationTimeout);
+
+      if (self._options.unref) {
+          self._timeout.unref();
+      }
+    }
+
+    self._fn(self._attempts);
+  }, timeout);
+
+  if (this._options.unref) {
+      timer.unref();
+  }
+
+  return true;
+};
+
+RetryOperation.prototype.attempt = function(fn, timeoutOps) {
+  this._fn = fn;
+
+  if (timeoutOps) {
+    if (timeoutOps.timeout) {
+      this._operationTimeout = timeoutOps.timeout;
+    }
+    if (timeoutOps.cb) {
+      this._operationTimeoutCb = timeoutOps.cb;
+    }
+  }
+
+  var self = this;
+  if (this._operationTimeoutCb) {
+    this._timeout = setTimeout(function() {
+      self._operationTimeoutCb();
+    }, self._operationTimeout);
+  }
+
+  this._operationStart = new Date().getTime();
+
+  this._fn(this._attempts);
+};
+
+RetryOperation.prototype.try = function(fn) {
+  console.log('Using RetryOperation.try() is deprecated');
+  this.attempt(fn);
+};
+
+RetryOperation.prototype.start = function(fn) {
+  console.log('Using RetryOperation.start() is deprecated');
+  this.attempt(fn);
+};
+
+RetryOperation.prototype.start = RetryOperation.prototype.try;
+
+RetryOperation.prototype.errors = function() {
+  return this._errors;
+};
+
+RetryOperation.prototype.attempts = function() {
+  return this._attempts;
+};
+
+RetryOperation.prototype.mainError = function() {
+  if (this._errors.length === 0) {
+    return null;
+  }
+
+  var counts = {};
+  var mainError = null;
+  var mainErrorCount = 0;
+
+  for (var i = 0; i < this._errors.length; i++) {
+    var error = this._errors[i];
+    var message = error.message;
+    var count = (counts[message] || 0) + 1;
+
+    counts[message] = count;
+
+    if (count >= mainErrorCount) {
+      mainError = error;
+      mainErrorCount = count;
+    }
+  }
+
+  return mainError;
+};
+
+},{}],133:[function(require,module,exports){
 'use strict'
 var Buffer = require('buffer').Buffer
 var inherits = require('inherits')
@@ -21697,7 +21983,7 @@ function fn5 (a, b, c, d, e, m, k, s) {
 
 module.exports = RIPEMD160
 
-},{"buffer":227,"hash-base":45,"inherits":46}],131:[function(require,module,exports){
+},{"buffer":233,"hash-base":45,"inherits":46}],134:[function(require,module,exports){
 /* eslint-disable node/no-deprecated-api */
 var buffer = require('buffer')
 var Buffer = buffer.Buffer
@@ -21761,7 +22047,7 @@ SafeBuffer.allocUnsafeSlow = function (size) {
   return buffer.SlowBuffer(size)
 }
 
-},{"buffer":227}],132:[function(require,module,exports){
+},{"buffer":233}],135:[function(require,module,exports){
 (function (process,Buffer){
 !function(globals){
 'use strict'
@@ -21843,7 +22129,7 @@ secureRandom.randomBuffer = function(byteCount) {
 }(this);
 
 }).call(this,require('_process'),require("buffer").Buffer)
-},{"_process":297,"buffer":227,"crypto":198}],133:[function(require,module,exports){
+},{"_process":303,"buffer":233,"crypto":204}],136:[function(require,module,exports){
 var Buffer = require('safe-buffer').Buffer
 
 // prototype class for hash functions
@@ -21926,7 +22212,7 @@ Hash.prototype._update = function () {
 
 module.exports = Hash
 
-},{"safe-buffer":131}],134:[function(require,module,exports){
+},{"safe-buffer":134}],137:[function(require,module,exports){
 var exports = module.exports = function SHA (algorithm) {
   algorithm = algorithm.toLowerCase()
 
@@ -21943,7 +22229,7 @@ exports.sha256 = require('./sha256')
 exports.sha384 = require('./sha384')
 exports.sha512 = require('./sha512')
 
-},{"./sha":135,"./sha1":136,"./sha224":137,"./sha256":138,"./sha384":139,"./sha512":140}],135:[function(require,module,exports){
+},{"./sha":138,"./sha1":139,"./sha224":140,"./sha256":141,"./sha384":142,"./sha512":143}],138:[function(require,module,exports){
 /*
  * A JavaScript implementation of the Secure Hash Algorithm, SHA-0, as defined
  * in FIPS PUB 180-1
@@ -22039,7 +22325,7 @@ Sha.prototype._hash = function () {
 
 module.exports = Sha
 
-},{"./hash":133,"inherits":46,"safe-buffer":131}],136:[function(require,module,exports){
+},{"./hash":136,"inherits":46,"safe-buffer":134}],139:[function(require,module,exports){
 /*
  * A JavaScript implementation of the Secure Hash Algorithm, SHA-1, as defined
  * in FIPS PUB 180-1
@@ -22140,7 +22426,7 @@ Sha1.prototype._hash = function () {
 
 module.exports = Sha1
 
-},{"./hash":133,"inherits":46,"safe-buffer":131}],137:[function(require,module,exports){
+},{"./hash":136,"inherits":46,"safe-buffer":134}],140:[function(require,module,exports){
 /**
  * A JavaScript implementation of the Secure Hash Algorithm, SHA-256, as defined
  * in FIPS 180-2
@@ -22195,7 +22481,7 @@ Sha224.prototype._hash = function () {
 
 module.exports = Sha224
 
-},{"./hash":133,"./sha256":138,"inherits":46,"safe-buffer":131}],138:[function(require,module,exports){
+},{"./hash":136,"./sha256":141,"inherits":46,"safe-buffer":134}],141:[function(require,module,exports){
 /**
  * A JavaScript implementation of the Secure Hash Algorithm, SHA-256, as defined
  * in FIPS 180-2
@@ -22332,7 +22618,7 @@ Sha256.prototype._hash = function () {
 
 module.exports = Sha256
 
-},{"./hash":133,"inherits":46,"safe-buffer":131}],139:[function(require,module,exports){
+},{"./hash":136,"inherits":46,"safe-buffer":134}],142:[function(require,module,exports){
 var inherits = require('inherits')
 var SHA512 = require('./sha512')
 var Hash = require('./hash')
@@ -22391,7 +22677,7 @@ Sha384.prototype._hash = function () {
 
 module.exports = Sha384
 
-},{"./hash":133,"./sha512":140,"inherits":46,"safe-buffer":131}],140:[function(require,module,exports){
+},{"./hash":136,"./sha512":143,"inherits":46,"safe-buffer":134}],143:[function(require,module,exports){
 var inherits = require('inherits')
 var Hash = require('./hash')
 var Buffer = require('safe-buffer').Buffer
@@ -22653,7 +22939,7 @@ Sha512.prototype._hash = function () {
 
 module.exports = Sha512
 
-},{"./hash":133,"inherits":46,"safe-buffer":131}],141:[function(require,module,exports){
+},{"./hash":136,"inherits":46,"safe-buffer":134}],144:[function(require,module,exports){
 module.exports={
   "transport": "http",
   "websocket": "wss://gtg.steem.house:8090",
@@ -22665,7 +22951,7 @@ module.exports={
   "chain_id": "0000000000000000000000000000000000000000000000000000000000000000"
 }
 
-},{}],142:[function(require,module,exports){
+},{}],145:[function(require,module,exports){
 'use strict';
 
 var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -23085,7 +23371,7 @@ var Steem = function (_EventEmitter) {
 var steem = new Steem(_config2.default);
 exports = module.exports = steem;
 exports.Steem = Steem;
-},{"../auth/ecc":148,"../auth/serializer":162,"../config":176,"../utils":179,"./methods":143,"./transports":146,"./transports/http":145,"@steemit/rpc-auth":3,"bluebird":9,"events":262}],143:[function(require,module,exports){
+},{"../auth/ecc":151,"../auth/serializer":165,"../config":179,"../utils":182,"./methods":146,"./transports":149,"./transports/http":148,"@steemit/rpc-auth":3,"bluebird":9,"events":268}],146:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -23483,7 +23769,7 @@ exports.default = [{
   "method": "get_market_history_buckets",
   "params": []
 }];
-},{}],144:[function(require,module,exports){
+},{}],147:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -23556,7 +23842,7 @@ exports.default = Transport;
 
 
 _bluebird2.default.promisifyAll(Transport.prototype);
-},{"bluebird":9,"events":262}],145:[function(require,module,exports){
+},{"bluebird":9,"events":268}],148:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -23574,6 +23860,10 @@ var _crossFetch2 = _interopRequireDefault(_crossFetch);
 var _debug = require('debug');
 
 var _debug2 = _interopRequireDefault(_debug);
+
+var _retry = require('retry');
+
+var _retry2 = _interopRequireDefault(_retry);
 
 var _base = require('./base');
 
@@ -23606,13 +23896,28 @@ var RPCError = function (_Error) {
   return RPCError;
 }(Error);
 
+/**
+ * Makes a JSON-RPC request using `fetch` or a user-provided `fetchMethod`.
+ *
+ * @param {string} uri - The URI to the JSON-RPC endpoint.
+ * @param {string} options.method - The remote JSON-RPC method to call.
+ * @param {string} options.id - ID for the request, for matching to a response.
+ * @param {*} options.params  - The params for the remote method.
+ * @param {function} [options.fetchMethod=fetch] - A function with the same
+ * signature as `fetch`, which can be used to make the network request, or for
+ * stubbing in tests.
+ */
+
+
 function jsonRpc(uri, _ref) {
   var method = _ref.method,
       id = _ref.id,
-      params = _ref.params;
+      params = _ref.params,
+      _ref$fetchMethod = _ref.fetchMethod,
+      fetchMethod = _ref$fetchMethod === undefined ? _crossFetch2.default : _ref$fetchMethod;
 
   var payload = { id: id, jsonrpc: '2.0', method: method, params: params };
-  return (0, _crossFetch2.default)(uri, {
+  return fetchMethod(uri, {
     body: JSON.stringify(payload),
     method: 'post',
     mode: 'cors',
@@ -23648,17 +23953,61 @@ var HttpTransport = function (_Transport) {
   _createClass(HttpTransport, [{
     key: 'send',
     value: function send(api, data, callback) {
+      var _this3 = this;
+
       if (this.options.useAppbaseApi) {
         api = 'condenser_api';
       }
       debug('Steem::send', api, data);
       var id = data.id || this.id++;
       var params = [api, data.method, data.params];
-      jsonRpc(this.options.uri, { method: 'call', id: id, params: params }).then(function (res) {
-        callback(null, res);
-      }, function (err) {
-        callback(err);
-      });
+      var retriable = this.retriable(api, data);
+      var fetchMethod = this.options.fetchMethod;
+      if (retriable) {
+        retriable.attempt(function (currentAttempt) {
+          jsonRpc(_this3.options.uri, { method: 'call', id: id, params: params, fetchMethod: fetchMethod }).then(function (res) {
+            callback(null, res);
+          }, function (err) {
+            if (retriable.retry(err)) {
+              return;
+            }
+            callback(retriable.mainError());
+          });
+        });
+      } else {
+        jsonRpc(this.options.uri, { method: 'call', id: id, params: params, fetchMethod: fetchMethod }).then(function (res) {
+          callback(null, res);
+        }, function (err) {
+          callback(err);
+        });
+      }
+    }
+  }, {
+    key: 'retriable',
+
+
+    // An object which can be used to track retries.
+    value: function retriable(api, data) {
+      if (this.nonRetriableOperations.some(function (o) {
+        return o === data.method;
+      })) {
+        // Do not retry if the operation is non-retriable.
+        return null;
+      } else if (Object(this.options.retry) === this.options.retry) {
+        // If `this.options.retry` is a map of options, pass those to operation.
+        return _retry2.default.operation(this.options.retry);
+      } else if (this.options.retry) {
+        // If `this.options.retry` is `true`, use default options.
+        return _retry2.default.operation();
+      } else {
+        // Otherwise, don't retry.
+        return null;
+      }
+    }
+  }, {
+    key: 'nonRetriableOperations',
+    get: function get() {
+      return this.options.nonRetriableOperations || ['broadcast_transaction', 'broadcast_transaction_with_callback', 'broadcast_transaction_synchronous', 'broadcast_block'];
     }
   }]);
 
@@ -23666,7 +24015,7 @@ var HttpTransport = function (_Transport) {
 }(_base2.default);
 
 exports.default = HttpTransport;
-},{"./base":144,"cross-fetch":35,"debug":36}],146:[function(require,module,exports){
+},{"./base":147,"cross-fetch":35,"debug":36,"retry":130}],149:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -23687,7 +24036,7 @@ exports.default = {
   http: _http2.default,
   ws: _ws2.default
 };
-},{"./http":145,"./ws":147}],147:[function(require,module,exports){
+},{"./http":148,"./ws":150}],150:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -23916,7 +24265,7 @@ var WsTransport = function (_Transport) {
 }(_base2.default);
 
 exports.default = WsTransport;
-},{"./base":144,"bluebird":9,"debug":36,"detect-node":38,"ws":198}],148:[function(require,module,exports){
+},{"./base":147,"bluebird":9,"debug":36,"detect-node":38,"ws":204}],151:[function(require,module,exports){
 "use strict";
 
 module.exports = {
@@ -23930,7 +24279,7 @@ module.exports = {
     hash: require("./src/hash"),
     ecc_config: require("../../config")
 };
-},{"../../config":176,"./src/address":149,"./src/aes":150,"./src/brain_key":151,"./src/hash":155,"./src/key_private":156,"./src/key_public":157,"./src/key_utils":158,"./src/signature":159}],149:[function(require,module,exports){
+},{"../../config":179,"./src/address":152,"./src/aes":153,"./src/brain_key":154,"./src/hash":158,"./src/key_private":159,"./src/key_public":160,"./src/key_utils":161,"./src/signature":162}],152:[function(require,module,exports){
 (function (Buffer){
 'use strict';
 
@@ -24017,7 +24366,7 @@ var Address = function () {
 
 module.exports = Address;
 }).call(this,require("buffer").Buffer)
-},{"../../../config":176,"./hash":155,"assert":194,"bs58":27,"buffer":227}],150:[function(require,module,exports){
+},{"../../../config":179,"./hash":158,"assert":197,"bs58":27,"buffer":233}],153:[function(require,module,exports){
 (function (Buffer){
 'use strict';
 
@@ -24204,7 +24553,7 @@ var toBinaryBuffer = function toBinaryBuffer(o) {
     return o ? Buffer.isBuffer(o) ? o : new Buffer(o, 'binary') : o;
 };
 }).call(this,require("buffer").Buffer)
-},{"./hash":155,"./key_private":156,"./key_public":157,"assert":194,"browserify-aes":12,"buffer":227,"bytebuffer":29,"secure-random":132}],151:[function(require,module,exports){
+},{"./hash":158,"./key_private":159,"./key_public":160,"assert":197,"browserify-aes":12,"buffer":233,"bytebuffer":29,"secure-random":135}],154:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -24218,7 +24567,7 @@ function normalize(brain_key) {
     brain_key = brain_key.trim();
     return brain_key.split(/[\t\n\v\f\r ]+/).join(' ');
 }
-},{}],152:[function(require,module,exports){
+},{}],155:[function(require,module,exports){
 (function (Buffer){
 'use strict';
 
@@ -24440,7 +24789,7 @@ module.exports = {
   verifyRaw: verifyRaw
 };
 }).call(this,require("buffer").Buffer)
-},{"./ecsignature":153,"./enforce_types":154,"./hash":155,"assert":194,"bigi":7,"buffer":227}],153:[function(require,module,exports){
+},{"./ecsignature":156,"./enforce_types":157,"./hash":158,"assert":197,"bigi":7,"buffer":233}],156:[function(require,module,exports){
 (function (Buffer){
 'use strict';
 
@@ -24571,7 +24920,7 @@ ECSignature.prototype.toScriptSignature = function (hashType) {
 
 module.exports = ECSignature;
 }).call(this,require("buffer").Buffer)
-},{"./enforce_types":154,"assert":194,"bigi":7,"buffer":227}],154:[function(require,module,exports){
+},{"./enforce_types":157,"assert":197,"bigi":7,"buffer":233}],157:[function(require,module,exports){
 (function (Buffer){
 'use strict';
 
@@ -24622,8 +24971,8 @@ function getName(fn) {
   var match = fn.toString().match(/function (.*?)\(/);
   return match ? match[1] : null;
 }
-}).call(this,{"isBuffer":require("../../../../../../../../../../../../usr/lib/node_modules/browserify/node_modules/is-buffer/index.js")})
-},{"../../../../../../../../../../../../usr/lib/node_modules/browserify/node_modules/is-buffer/index.js":280}],155:[function(require,module,exports){
+}).call(this,{"isBuffer":require("../../../../../../../../../../usr/local/lib/node_modules/browserify/node_modules/is-buffer/index.js")})
+},{"../../../../../../../../../../usr/local/lib/node_modules/browserify/node_modules/is-buffer/index.js":286}],158:[function(require,module,exports){
 'use strict';
 
 var _createHash = require('create-hash');
@@ -24671,12 +25020,12 @@ function ripemd160(data) {
 // function hash160(buffer) {
 //   return ripemd160(sha256(buffer))
 // }
-//
+// 
 // function hash256(buffer) {
 //   return sha256(sha256(buffer))
 // }
 
-//
+// 
 // function HmacSHA512(buffer, secret) {
 //   return crypto.createHmac('sha512', secret).update(buffer).digest()
 // }
@@ -24691,7 +25040,7 @@ module.exports = {
     // hash256: hash256,
     // HmacSHA512: HmacSHA512
 };
-},{"create-hash":31,"create-hmac":33}],156:[function(require,module,exports){
+},{"create-hash":31,"create-hmac":33}],159:[function(require,module,exports){
 (function (Buffer){
 'use strict';
 
@@ -24906,7 +25255,7 @@ var toPublic = function toPublic(data) {
     return data == null ? data : data.Q ? data : PublicKey.fromStringOrThrow(data);
 };
 }).call(this,require("buffer").Buffer)
-},{"./hash":155,"./key_public":157,"assert":194,"bigi":7,"bs58":27,"buffer":227,"ecurve":41}],157:[function(require,module,exports){
+},{"./hash":158,"./key_public":160,"assert":197,"bigi":7,"bs58":27,"buffer":233,"ecurve":41}],160:[function(require,module,exports){
 (function (Buffer){
 'use strict';
 
@@ -25124,7 +25473,7 @@ var PublicKey = function () {
 
 module.exports = PublicKey;
 }).call(this,require("buffer").Buffer)
-},{"../../../config":176,"./hash":155,"assert":194,"bigi":7,"bs58":27,"buffer":227,"ecurve":41}],158:[function(require,module,exports){
+},{"../../../config":179,"./hash":158,"assert":197,"bigi":7,"bs58":27,"buffer":233,"ecurve":41}],161:[function(require,module,exports){
 (function (Buffer){
 'use strict';
 
@@ -25239,7 +25588,7 @@ module.exports = {
     }
 };
 }).call(this,require("buffer").Buffer)
-},{"./hash":155,"./key_private":156,"buffer":227,"secure-random":132}],159:[function(require,module,exports){
+},{"./hash":158,"./key_private":159,"buffer":233,"secure-random":135}],162:[function(require,module,exports){
 (function (Buffer){
 'use strict';
 
@@ -25429,7 +25778,7 @@ var toPrivateObj = function toPrivateObj(o) {
 };
 module.exports = Signature;
 }).call(this,require("buffer").Buffer)
-},{"./ecdsa":152,"./hash":155,"./key_private":156,"./key_public":157,"assert":194,"bigi":7,"buffer":227,"ecurve":41}],160:[function(require,module,exports){
+},{"./ecdsa":155,"./hash":158,"./key_private":159,"./key_public":160,"assert":197,"bigi":7,"buffer":233,"ecurve":41}],163:[function(require,module,exports){
 (function (Buffer){
 'use strict';
 
@@ -25558,7 +25907,7 @@ Auth.signTransaction = function (trx, keys) {
 
 module.exports = Auth;
 }).call(this,require("buffer").Buffer)
-},{"../config":176,"./ecc/src/hash":155,"./ecc/src/key_private":156,"./ecc/src/key_public":157,"./ecc/src/signature":159,"./serializer/src/operations":168,"bigi":7,"bs58":27,"buffer":227,"ecurve":41}],161:[function(require,module,exports){
+},{"../config":179,"./ecc/src/hash":158,"./ecc/src/key_private":159,"./ecc/src/key_public":160,"./ecc/src/signature":162,"./serializer/src/operations":171,"bigi":7,"bs58":27,"buffer":233,"ecurve":41}],164:[function(require,module,exports){
 (function (Buffer){
 'use strict';
 
@@ -25708,7 +26057,7 @@ var toPublicObj = function toPublicObj(o) {
     return o ? o.Q ? o : _ecc.PublicKey.fromString(o) : o /*null or undefined*/;
 };
 }).call(this,require("buffer").Buffer)
-},{"./ecc":148,"./serializer":162,"assert":194,"bs58":27,"buffer":227,"bytebuffer":29}],162:[function(require,module,exports){
+},{"./ecc":151,"./serializer":165,"assert":197,"bs58":27,"buffer":233,"bytebuffer":29}],165:[function(require,module,exports){
 'use strict';
 
 module.exports = {
@@ -25730,7 +26079,7 @@ module.exports = {
 
     number_utils: require('./src/number_utils')
 };
-},{"./src/fast_parser":165,"./src/number_utils":166,"./src/operations":168,"./src/serializer":169,"./src/template":170,"./src/types":171}],163:[function(require,module,exports){
+},{"./src/fast_parser":168,"./src/number_utils":169,"./src/operations":171,"./src/serializer":172,"./src/template":173,"./src/types":174}],166:[function(require,module,exports){
 "use strict";
 
 var ChainTypes;
@@ -25807,7 +26156,7 @@ ChainTypes.object_type = {
   "null": 0,
   base: 1
 };
-},{}],164:[function(require,module,exports){
+},{}],167:[function(require,module,exports){
 "use strict";
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
@@ -25850,7 +26199,7 @@ var ErrorWithCause = function () {
 }();
 
 module.exports = ErrorWithCause;
-},{}],165:[function(require,module,exports){
+},{}],168:[function(require,module,exports){
 (function (Buffer){
 'use strict';
 
@@ -25930,7 +26279,7 @@ var FastParser = function () {
 
 module.exports = FastParser;
 }).call(this,require("buffer").Buffer)
-},{"../../ecc":148,"buffer":227}],166:[function(require,module,exports){
+},{"../../ecc":151,"buffer":233}],169:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -25998,7 +26347,7 @@ function fromImpliedDecimal(number, precision) {
     var dec_string = number.substring(number.length - precision);
     return number.substring(0, number.length - precision) + (dec_string ? "." + dec_string : "");
 }
-},{"assert":194}],167:[function(require,module,exports){
+},{"assert":197}],170:[function(require,module,exports){
 'use strict';
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
@@ -26067,7 +26416,7 @@ var ObjectId = function () {
 }();
 
 module.exports = ObjectId;
-},{"./validation":172,"bytebuffer":29}],168:[function(require,module,exports){
+},{"./validation":175,"bytebuffer":29}],171:[function(require,module,exports){
 "use strict";
 
 var _types = require("./types");
@@ -26165,12 +26514,12 @@ Replace:  var operation = static_variant([
 with:     operation.st_operations = [
 
 Delete (these are custom types instead):
-let public_key = new Serializer(
+let public_key = new Serializer( 
     "public_key",
     {key_data: bytes(33)}
 );
 
-let asset = new Serializer(
+let asset = new Serializer( 
     "asset",
     {amount: int64,
     symbol: uint64}
@@ -26674,7 +27023,7 @@ var encrypted_memo = new Serializer("encrypted_memo", { from: public_key,
 npm test
 
 */
-},{"./serializer":169,"./types":171}],169:[function(require,module,exports){
+},{"./serializer":172,"./types":174}],172:[function(require,module,exports){
 (function (process,Buffer){
 'use strict';
 
@@ -26888,7 +27237,7 @@ var Serializer = function () {
 
 module.exports = Serializer;
 }).call(this,require('_process'),require("buffer").Buffer)
-},{"./error_with_cause":164,"_process":297,"buffer":227,"bytebuffer":29}],170:[function(require,module,exports){
+},{"./error_with_cause":167,"_process":303,"buffer":233,"bytebuffer":29}],173:[function(require,module,exports){
 "use strict";
 
 /** Console print any transaction object with zero default values. */
@@ -26906,7 +27255,7 @@ module.exports = function template(op) {
     // copy-paste one-lineer
     console.error(JSON.stringify(object));
 };
-},{}],171:[function(require,module,exports){
+},{}],174:[function(require,module,exports){
 (function (process,Buffer){
 'use strict';
 
@@ -27935,7 +28284,7 @@ var sortOperation = function sortOperation(array, st_operation) {
     });
 };
 }).call(this,require('_process'),require("buffer").Buffer)
-},{"../../ecc":148,"./ChainTypes":163,"./fast_parser":165,"./number_utils":166,"./object_id":167,"./validation":172,"_process":297,"buffer":227}],172:[function(require,module,exports){
+},{"../../ecc":151,"./ChainTypes":166,"./fast_parser":168,"./number_utils":169,"./object_id":170,"./validation":175,"_process":303,"buffer":233}],175:[function(require,module,exports){
 'use strict';
 
 var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
@@ -27964,7 +28313,7 @@ var MAX_SAFE_INT = 9007199254740991;
 var MIN_SAFE_INT = -9007199254740991;
 
 /**
-    Most validations are skipped and the value returned unchanged when an empty string, null, or undefined is encountered (except "required").
+    Most validations are skipped and the value returned unchanged when an empty string, null, or undefined is encountered (except "required"). 
 
     Validations support a string format for dealing with large numbers.
 */
@@ -28296,7 +28645,7 @@ module.exports = _my = {
         throw 'unsupported type ' + field_name + ': (' + (typeof value === 'undefined' ? 'undefined' : _typeof(value)) + ') ' + value;
     }
 };
-},{"./ChainTypes":163,"bytebuffer":29}],173:[function(require,module,exports){
+},{"./ChainTypes":166,"bytebuffer":29}],176:[function(require,module,exports){
 'use strict';
 
 var _slicedToArray = function () { function sliceIterator(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"]) _i["return"](); } finally { if (_d) throw _e; } } return _arr; } return function (arr, i) { if (Array.isArray(arr)) { return arr; } else if (Symbol.iterator in Object(arr)) { return sliceIterator(arr, i); } else { throw new TypeError("Invalid attempt to destructure non-iterable instance"); } }; }();
@@ -28474,7 +28823,7 @@ exports = module.exports = function (steemBroadcast) {
     });
   };
 };
-},{"../api":142}],174:[function(require,module,exports){
+},{"../api":145}],177:[function(require,module,exports){
 (function (Buffer){
 'use strict';
 
@@ -28604,7 +28953,7 @@ _bluebird2.default.promisifyAll(steemBroadcast);
 
 exports = module.exports = steemBroadcast;
 }).call(this,require("buffer").Buffer)
-},{"../api":142,"../auth":160,"../formatter":177,"../utils":179,"./helpers":173,"./operations":175,"bluebird":9,"buffer":227,"debug":36}],175:[function(require,module,exports){
+},{"../api":145,"../auth":163,"../formatter":180,"../utils":182,"./helpers":176,"./operations":178,"bluebird":9,"buffer":233,"debug":36}],178:[function(require,module,exports){
 "use strict";
 
 module.exports = [{
@@ -28804,7 +29153,7 @@ module.exports = [{
   "operation": "fill_transfer_from_savings",
   "params": ["from", "to", "amount", "request_id", "memo"]
 }];
-},{}],176:[function(require,module,exports){
+},{}],179:[function(require,module,exports){
 'use strict';
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
@@ -28850,7 +29199,7 @@ if (typeof module.exports.Config !== 'undefined') {
   throw new Error("default config.json file may not contain a property 'Config'");
 }
 module.exports.Config = Config;
-},{"../config.json":141,"lodash/each":108}],177:[function(require,module,exports){
+},{"../config.json":144,"lodash/each":108}],180:[function(require,module,exports){
 "use strict";
 
 var _slicedToArray = function () { function sliceIterator(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"]) _i["return"](); } finally { if (_d) throw _e; } } return _arr; } return function (arr, i) { if (Array.isArray(arr)) { return arr; } else if (Symbol.iterator in Object(arr)) { return sliceIterator(arr, i); } else { throw new TypeError("Invalid attempt to destructure non-iterable instance"); } }; }();
@@ -28910,6 +29259,17 @@ module.exports = function (steemAPI) {
     return { savings_pending: savings_pending, savings_sbd_pending: savings_sbd_pending };
   }
 
+  function pricePerSteem(feed_price) {
+    var price_per_steem = undefined;
+    var base = feed_price.base,
+        quote = feed_price.quote;
+
+    if (/ SBD$/.test(base) && / STEEM$/.test(quote)) {
+      price_per_steem = parseFloat(base.split(" ")[0]) / parseFloat(quote.split(" ")[0]);
+    }
+    return price_per_steem;
+  }
+
   function estimateAccountValue(account) {
     var _ref = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {},
         gprops = _ref.gprops,
@@ -28953,12 +29313,8 @@ module.exports = function (steemAPI) {
     }
 
     return Promise.all(promises).then(function () {
-      var price_per_steem = undefined;
-      var _feed_price = feed_price,
-          base = _feed_price.base,
-          quote = _feed_price.quote;
+      var price_per_steem = pricePerSteem(feed_price);
 
-      if (/ SBD$/.test(base) && / STEEM$/.test(quote)) price_per_steem = parseFloat(base.split(" ")[0]);
       var savings_balance = account.savings_balance;
       var savings_sbd_balance = account.savings_sbd_balance;
       var balance_steem = parseFloat(account.balance.split(" ")[0]);
@@ -29029,10 +29385,11 @@ module.exports = function (steemAPI) {
     numberWithCommas: numberWithCommas,
     vestingSteem: vestingSteem,
     estimateAccountValue: estimateAccountValue,
-    createSuggestedPassword: createSuggestedPassword
+    createSuggestedPassword: createSuggestedPassword,
+    pricePerSteem: pricePerSteem
   };
 };
-},{"./auth/ecc":148,"lodash/get":111}],178:[function(require,module,exports){
+},{"./auth/ecc":151,"lodash/get":111}],181:[function(require,module,exports){
 'use strict';
 
 var api = require('./api');
@@ -29052,7 +29409,7 @@ module.exports = {
   config: config,
   utils: utils
 };
-},{"./api":142,"./auth":160,"./auth/memo":161,"./broadcast":174,"./config":176,"./formatter":177,"./utils":179}],179:[function(require,module,exports){
+},{"./api":145,"./auth":163,"./auth/memo":164,"./broadcast":177,"./config":179,"./formatter":180,"./utils":182}],182:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -29108,7 +29465,7 @@ function validateAccountName(value) {
   }
   return null;
 }
-},{}],180:[function(require,module,exports){
+},{}],183:[function(require,module,exports){
 var asn1 = exports;
 
 asn1.bignum = require('bn.js');
@@ -29119,7 +29476,7 @@ asn1.constants = require('./asn1/constants');
 asn1.decoders = require('./asn1/decoders');
 asn1.encoders = require('./asn1/encoders');
 
-},{"./asn1/api":181,"./asn1/base":183,"./asn1/constants":187,"./asn1/decoders":189,"./asn1/encoders":192,"bn.js":196}],181:[function(require,module,exports){
+},{"./asn1/api":184,"./asn1/base":186,"./asn1/constants":190,"./asn1/decoders":192,"./asn1/encoders":195,"bn.js":202}],184:[function(require,module,exports){
 var asn1 = require('../asn1');
 var inherits = require('inherits');
 
@@ -29182,7 +29539,7 @@ Entity.prototype.encode = function encode(data, enc, /* internal */ reporter) {
   return this._getEncoder(enc).encode(data, reporter);
 };
 
-},{"../asn1":180,"inherits":279,"vm":335}],182:[function(require,module,exports){
+},{"../asn1":183,"inherits":285,"vm":339}],185:[function(require,module,exports){
 var inherits = require('inherits');
 var Reporter = require('../base').Reporter;
 var Buffer = require('buffer').Buffer;
@@ -29300,7 +29657,7 @@ EncoderBuffer.prototype.join = function join(out, offset) {
   return out;
 };
 
-},{"../base":183,"buffer":227,"inherits":279}],183:[function(require,module,exports){
+},{"../base":186,"buffer":233,"inherits":285}],186:[function(require,module,exports){
 var base = exports;
 
 base.Reporter = require('./reporter').Reporter;
@@ -29308,7 +29665,7 @@ base.DecoderBuffer = require('./buffer').DecoderBuffer;
 base.EncoderBuffer = require('./buffer').EncoderBuffer;
 base.Node = require('./node');
 
-},{"./buffer":182,"./node":184,"./reporter":185}],184:[function(require,module,exports){
+},{"./buffer":185,"./node":187,"./reporter":188}],187:[function(require,module,exports){
 var Reporter = require('../base').Reporter;
 var EncoderBuffer = require('../base').EncoderBuffer;
 var DecoderBuffer = require('../base').DecoderBuffer;
@@ -29944,7 +30301,7 @@ Node.prototype._isPrintstr = function isPrintstr(str) {
   return /^[A-Za-z0-9 '\(\)\+,\-\.\/:=\?]*$/.test(str);
 };
 
-},{"../base":183,"minimalistic-assert":284}],185:[function(require,module,exports){
+},{"../base":186,"minimalistic-assert":290}],188:[function(require,module,exports){
 var inherits = require('inherits');
 
 function Reporter(options) {
@@ -30067,7 +30424,7 @@ ReporterError.prototype.rethrow = function rethrow(msg) {
   return this;
 };
 
-},{"inherits":279}],186:[function(require,module,exports){
+},{"inherits":285}],189:[function(require,module,exports){
 var constants = require('../constants');
 
 exports.tagClass = {
@@ -30111,7 +30468,7 @@ exports.tag = {
 };
 exports.tagByName = constants._reverse(exports.tag);
 
-},{"../constants":187}],187:[function(require,module,exports){
+},{"../constants":190}],190:[function(require,module,exports){
 var constants = exports;
 
 // Helper
@@ -30132,7 +30489,7 @@ constants._reverse = function reverse(map) {
 
 constants.der = require('./der');
 
-},{"./der":186}],188:[function(require,module,exports){
+},{"./der":189}],191:[function(require,module,exports){
 var inherits = require('inherits');
 
 var asn1 = require('../../asn1');
@@ -30458,13 +30815,13 @@ function derDecodeLen(buf, primitive, fail) {
   return len;
 }
 
-},{"../../asn1":180,"inherits":279}],189:[function(require,module,exports){
+},{"../../asn1":183,"inherits":285}],192:[function(require,module,exports){
 var decoders = exports;
 
 decoders.der = require('./der');
 decoders.pem = require('./pem');
 
-},{"./der":188,"./pem":190}],190:[function(require,module,exports){
+},{"./der":191,"./pem":193}],193:[function(require,module,exports){
 var inherits = require('inherits');
 var Buffer = require('buffer').Buffer;
 
@@ -30515,7 +30872,7 @@ PEMDecoder.prototype.decode = function decode(data, options) {
   return DERDecoder.prototype.decode.call(this, input, options);
 };
 
-},{"./der":188,"buffer":227,"inherits":279}],191:[function(require,module,exports){
+},{"./der":191,"buffer":233,"inherits":285}],194:[function(require,module,exports){
 var inherits = require('inherits');
 var Buffer = require('buffer').Buffer;
 
@@ -30812,13 +31169,13 @@ function encodeTag(tag, primitive, cls, reporter) {
   return res;
 }
 
-},{"../../asn1":180,"buffer":227,"inherits":279}],192:[function(require,module,exports){
+},{"../../asn1":183,"buffer":233,"inherits":285}],195:[function(require,module,exports){
 var encoders = exports;
 
 encoders.der = require('./der');
 encoders.pem = require('./pem');
 
-},{"./der":191,"./pem":193}],193:[function(require,module,exports){
+},{"./der":194,"./pem":196}],196:[function(require,module,exports){
 var inherits = require('inherits');
 
 var DEREncoder = require('./der');
@@ -30841,7 +31198,7 @@ PEMEncoder.prototype.encode = function encode(data, options) {
   return out.join('\n');
 };
 
-},{"./der":191,"inherits":279}],194:[function(require,module,exports){
+},{"./der":194,"inherits":285}],197:[function(require,module,exports){
 (function (global){
 'use strict';
 
@@ -31335,7 +31692,606 @@ var objectKeys = Object.keys || function (obj) {
 };
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"util/":334}],195:[function(require,module,exports){
+},{"util/":200}],198:[function(require,module,exports){
+arguments[4][46][0].apply(exports,arguments)
+},{"dup":46}],199:[function(require,module,exports){
+module.exports = function isBuffer(arg) {
+  return arg && typeof arg === 'object'
+    && typeof arg.copy === 'function'
+    && typeof arg.fill === 'function'
+    && typeof arg.readUInt8 === 'function';
+}
+},{}],200:[function(require,module,exports){
+(function (process,global){
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var formatRegExp = /%[sdj%]/g;
+exports.format = function(f) {
+  if (!isString(f)) {
+    var objects = [];
+    for (var i = 0; i < arguments.length; i++) {
+      objects.push(inspect(arguments[i]));
+    }
+    return objects.join(' ');
+  }
+
+  var i = 1;
+  var args = arguments;
+  var len = args.length;
+  var str = String(f).replace(formatRegExp, function(x) {
+    if (x === '%%') return '%';
+    if (i >= len) return x;
+    switch (x) {
+      case '%s': return String(args[i++]);
+      case '%d': return Number(args[i++]);
+      case '%j':
+        try {
+          return JSON.stringify(args[i++]);
+        } catch (_) {
+          return '[Circular]';
+        }
+      default:
+        return x;
+    }
+  });
+  for (var x = args[i]; i < len; x = args[++i]) {
+    if (isNull(x) || !isObject(x)) {
+      str += ' ' + x;
+    } else {
+      str += ' ' + inspect(x);
+    }
+  }
+  return str;
+};
+
+
+// Mark that a method should not be used.
+// Returns a modified function which warns once by default.
+// If --no-deprecation is set, then it is a no-op.
+exports.deprecate = function(fn, msg) {
+  // Allow for deprecating things in the process of starting up.
+  if (isUndefined(global.process)) {
+    return function() {
+      return exports.deprecate(fn, msg).apply(this, arguments);
+    };
+  }
+
+  if (process.noDeprecation === true) {
+    return fn;
+  }
+
+  var warned = false;
+  function deprecated() {
+    if (!warned) {
+      if (process.throwDeprecation) {
+        throw new Error(msg);
+      } else if (process.traceDeprecation) {
+        console.trace(msg);
+      } else {
+        console.error(msg);
+      }
+      warned = true;
+    }
+    return fn.apply(this, arguments);
+  }
+
+  return deprecated;
+};
+
+
+var debugs = {};
+var debugEnviron;
+exports.debuglog = function(set) {
+  if (isUndefined(debugEnviron))
+    debugEnviron = process.env.NODE_DEBUG || '';
+  set = set.toUpperCase();
+  if (!debugs[set]) {
+    if (new RegExp('\\b' + set + '\\b', 'i').test(debugEnviron)) {
+      var pid = process.pid;
+      debugs[set] = function() {
+        var msg = exports.format.apply(exports, arguments);
+        console.error('%s %d: %s', set, pid, msg);
+      };
+    } else {
+      debugs[set] = function() {};
+    }
+  }
+  return debugs[set];
+};
+
+
+/**
+ * Echos the value of a value. Trys to print the value out
+ * in the best way possible given the different types.
+ *
+ * @param {Object} obj The object to print out.
+ * @param {Object} opts Optional options object that alters the output.
+ */
+/* legacy: obj, showHidden, depth, colors*/
+function inspect(obj, opts) {
+  // default options
+  var ctx = {
+    seen: [],
+    stylize: stylizeNoColor
+  };
+  // legacy...
+  if (arguments.length >= 3) ctx.depth = arguments[2];
+  if (arguments.length >= 4) ctx.colors = arguments[3];
+  if (isBoolean(opts)) {
+    // legacy...
+    ctx.showHidden = opts;
+  } else if (opts) {
+    // got an "options" object
+    exports._extend(ctx, opts);
+  }
+  // set default options
+  if (isUndefined(ctx.showHidden)) ctx.showHidden = false;
+  if (isUndefined(ctx.depth)) ctx.depth = 2;
+  if (isUndefined(ctx.colors)) ctx.colors = false;
+  if (isUndefined(ctx.customInspect)) ctx.customInspect = true;
+  if (ctx.colors) ctx.stylize = stylizeWithColor;
+  return formatValue(ctx, obj, ctx.depth);
+}
+exports.inspect = inspect;
+
+
+// http://en.wikipedia.org/wiki/ANSI_escape_code#graphics
+inspect.colors = {
+  'bold' : [1, 22],
+  'italic' : [3, 23],
+  'underline' : [4, 24],
+  'inverse' : [7, 27],
+  'white' : [37, 39],
+  'grey' : [90, 39],
+  'black' : [30, 39],
+  'blue' : [34, 39],
+  'cyan' : [36, 39],
+  'green' : [32, 39],
+  'magenta' : [35, 39],
+  'red' : [31, 39],
+  'yellow' : [33, 39]
+};
+
+// Don't use 'blue' not visible on cmd.exe
+inspect.styles = {
+  'special': 'cyan',
+  'number': 'yellow',
+  'boolean': 'yellow',
+  'undefined': 'grey',
+  'null': 'bold',
+  'string': 'green',
+  'date': 'magenta',
+  // "name": intentionally not styling
+  'regexp': 'red'
+};
+
+
+function stylizeWithColor(str, styleType) {
+  var style = inspect.styles[styleType];
+
+  if (style) {
+    return '\u001b[' + inspect.colors[style][0] + 'm' + str +
+           '\u001b[' + inspect.colors[style][1] + 'm';
+  } else {
+    return str;
+  }
+}
+
+
+function stylizeNoColor(str, styleType) {
+  return str;
+}
+
+
+function arrayToHash(array) {
+  var hash = {};
+
+  array.forEach(function(val, idx) {
+    hash[val] = true;
+  });
+
+  return hash;
+}
+
+
+function formatValue(ctx, value, recurseTimes) {
+  // Provide a hook for user-specified inspect functions.
+  // Check that value is an object with an inspect function on it
+  if (ctx.customInspect &&
+      value &&
+      isFunction(value.inspect) &&
+      // Filter out the util module, it's inspect function is special
+      value.inspect !== exports.inspect &&
+      // Also filter out any prototype objects using the circular check.
+      !(value.constructor && value.constructor.prototype === value)) {
+    var ret = value.inspect(recurseTimes, ctx);
+    if (!isString(ret)) {
+      ret = formatValue(ctx, ret, recurseTimes);
+    }
+    return ret;
+  }
+
+  // Primitive types cannot have properties
+  var primitive = formatPrimitive(ctx, value);
+  if (primitive) {
+    return primitive;
+  }
+
+  // Look up the keys of the object.
+  var keys = Object.keys(value);
+  var visibleKeys = arrayToHash(keys);
+
+  if (ctx.showHidden) {
+    keys = Object.getOwnPropertyNames(value);
+  }
+
+  // IE doesn't make error fields non-enumerable
+  // http://msdn.microsoft.com/en-us/library/ie/dww52sbt(v=vs.94).aspx
+  if (isError(value)
+      && (keys.indexOf('message') >= 0 || keys.indexOf('description') >= 0)) {
+    return formatError(value);
+  }
+
+  // Some type of object without properties can be shortcutted.
+  if (keys.length === 0) {
+    if (isFunction(value)) {
+      var name = value.name ? ': ' + value.name : '';
+      return ctx.stylize('[Function' + name + ']', 'special');
+    }
+    if (isRegExp(value)) {
+      return ctx.stylize(RegExp.prototype.toString.call(value), 'regexp');
+    }
+    if (isDate(value)) {
+      return ctx.stylize(Date.prototype.toString.call(value), 'date');
+    }
+    if (isError(value)) {
+      return formatError(value);
+    }
+  }
+
+  var base = '', array = false, braces = ['{', '}'];
+
+  // Make Array say that they are Array
+  if (isArray(value)) {
+    array = true;
+    braces = ['[', ']'];
+  }
+
+  // Make functions say that they are functions
+  if (isFunction(value)) {
+    var n = value.name ? ': ' + value.name : '';
+    base = ' [Function' + n + ']';
+  }
+
+  // Make RegExps say that they are RegExps
+  if (isRegExp(value)) {
+    base = ' ' + RegExp.prototype.toString.call(value);
+  }
+
+  // Make dates with properties first say the date
+  if (isDate(value)) {
+    base = ' ' + Date.prototype.toUTCString.call(value);
+  }
+
+  // Make error with message first say the error
+  if (isError(value)) {
+    base = ' ' + formatError(value);
+  }
+
+  if (keys.length === 0 && (!array || value.length == 0)) {
+    return braces[0] + base + braces[1];
+  }
+
+  if (recurseTimes < 0) {
+    if (isRegExp(value)) {
+      return ctx.stylize(RegExp.prototype.toString.call(value), 'regexp');
+    } else {
+      return ctx.stylize('[Object]', 'special');
+    }
+  }
+
+  ctx.seen.push(value);
+
+  var output;
+  if (array) {
+    output = formatArray(ctx, value, recurseTimes, visibleKeys, keys);
+  } else {
+    output = keys.map(function(key) {
+      return formatProperty(ctx, value, recurseTimes, visibleKeys, key, array);
+    });
+  }
+
+  ctx.seen.pop();
+
+  return reduceToSingleString(output, base, braces);
+}
+
+
+function formatPrimitive(ctx, value) {
+  if (isUndefined(value))
+    return ctx.stylize('undefined', 'undefined');
+  if (isString(value)) {
+    var simple = '\'' + JSON.stringify(value).replace(/^"|"$/g, '')
+                                             .replace(/'/g, "\\'")
+                                             .replace(/\\"/g, '"') + '\'';
+    return ctx.stylize(simple, 'string');
+  }
+  if (isNumber(value))
+    return ctx.stylize('' + value, 'number');
+  if (isBoolean(value))
+    return ctx.stylize('' + value, 'boolean');
+  // For some reason typeof null is "object", so special case here.
+  if (isNull(value))
+    return ctx.stylize('null', 'null');
+}
+
+
+function formatError(value) {
+  return '[' + Error.prototype.toString.call(value) + ']';
+}
+
+
+function formatArray(ctx, value, recurseTimes, visibleKeys, keys) {
+  var output = [];
+  for (var i = 0, l = value.length; i < l; ++i) {
+    if (hasOwnProperty(value, String(i))) {
+      output.push(formatProperty(ctx, value, recurseTimes, visibleKeys,
+          String(i), true));
+    } else {
+      output.push('');
+    }
+  }
+  keys.forEach(function(key) {
+    if (!key.match(/^\d+$/)) {
+      output.push(formatProperty(ctx, value, recurseTimes, visibleKeys,
+          key, true));
+    }
+  });
+  return output;
+}
+
+
+function formatProperty(ctx, value, recurseTimes, visibleKeys, key, array) {
+  var name, str, desc;
+  desc = Object.getOwnPropertyDescriptor(value, key) || { value: value[key] };
+  if (desc.get) {
+    if (desc.set) {
+      str = ctx.stylize('[Getter/Setter]', 'special');
+    } else {
+      str = ctx.stylize('[Getter]', 'special');
+    }
+  } else {
+    if (desc.set) {
+      str = ctx.stylize('[Setter]', 'special');
+    }
+  }
+  if (!hasOwnProperty(visibleKeys, key)) {
+    name = '[' + key + ']';
+  }
+  if (!str) {
+    if (ctx.seen.indexOf(desc.value) < 0) {
+      if (isNull(recurseTimes)) {
+        str = formatValue(ctx, desc.value, null);
+      } else {
+        str = formatValue(ctx, desc.value, recurseTimes - 1);
+      }
+      if (str.indexOf('\n') > -1) {
+        if (array) {
+          str = str.split('\n').map(function(line) {
+            return '  ' + line;
+          }).join('\n').substr(2);
+        } else {
+          str = '\n' + str.split('\n').map(function(line) {
+            return '   ' + line;
+          }).join('\n');
+        }
+      }
+    } else {
+      str = ctx.stylize('[Circular]', 'special');
+    }
+  }
+  if (isUndefined(name)) {
+    if (array && key.match(/^\d+$/)) {
+      return str;
+    }
+    name = JSON.stringify('' + key);
+    if (name.match(/^"([a-zA-Z_][a-zA-Z_0-9]*)"$/)) {
+      name = name.substr(1, name.length - 2);
+      name = ctx.stylize(name, 'name');
+    } else {
+      name = name.replace(/'/g, "\\'")
+                 .replace(/\\"/g, '"')
+                 .replace(/(^"|"$)/g, "'");
+      name = ctx.stylize(name, 'string');
+    }
+  }
+
+  return name + ': ' + str;
+}
+
+
+function reduceToSingleString(output, base, braces) {
+  var numLinesEst = 0;
+  var length = output.reduce(function(prev, cur) {
+    numLinesEst++;
+    if (cur.indexOf('\n') >= 0) numLinesEst++;
+    return prev + cur.replace(/\u001b\[\d\d?m/g, '').length + 1;
+  }, 0);
+
+  if (length > 60) {
+    return braces[0] +
+           (base === '' ? '' : base + '\n ') +
+           ' ' +
+           output.join(',\n  ') +
+           ' ' +
+           braces[1];
+  }
+
+  return braces[0] + base + ' ' + output.join(', ') + ' ' + braces[1];
+}
+
+
+// NOTE: These type checking functions intentionally don't use `instanceof`
+// because it is fragile and can be easily faked with `Object.create()`.
+function isArray(ar) {
+  return Array.isArray(ar);
+}
+exports.isArray = isArray;
+
+function isBoolean(arg) {
+  return typeof arg === 'boolean';
+}
+exports.isBoolean = isBoolean;
+
+function isNull(arg) {
+  return arg === null;
+}
+exports.isNull = isNull;
+
+function isNullOrUndefined(arg) {
+  return arg == null;
+}
+exports.isNullOrUndefined = isNullOrUndefined;
+
+function isNumber(arg) {
+  return typeof arg === 'number';
+}
+exports.isNumber = isNumber;
+
+function isString(arg) {
+  return typeof arg === 'string';
+}
+exports.isString = isString;
+
+function isSymbol(arg) {
+  return typeof arg === 'symbol';
+}
+exports.isSymbol = isSymbol;
+
+function isUndefined(arg) {
+  return arg === void 0;
+}
+exports.isUndefined = isUndefined;
+
+function isRegExp(re) {
+  return isObject(re) && objectToString(re) === '[object RegExp]';
+}
+exports.isRegExp = isRegExp;
+
+function isObject(arg) {
+  return typeof arg === 'object' && arg !== null;
+}
+exports.isObject = isObject;
+
+function isDate(d) {
+  return isObject(d) && objectToString(d) === '[object Date]';
+}
+exports.isDate = isDate;
+
+function isError(e) {
+  return isObject(e) &&
+      (objectToString(e) === '[object Error]' || e instanceof Error);
+}
+exports.isError = isError;
+
+function isFunction(arg) {
+  return typeof arg === 'function';
+}
+exports.isFunction = isFunction;
+
+function isPrimitive(arg) {
+  return arg === null ||
+         typeof arg === 'boolean' ||
+         typeof arg === 'number' ||
+         typeof arg === 'string' ||
+         typeof arg === 'symbol' ||  // ES6 symbol
+         typeof arg === 'undefined';
+}
+exports.isPrimitive = isPrimitive;
+
+exports.isBuffer = require('./support/isBuffer');
+
+function objectToString(o) {
+  return Object.prototype.toString.call(o);
+}
+
+
+function pad(n) {
+  return n < 10 ? '0' + n.toString(10) : n.toString(10);
+}
+
+
+var months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep',
+              'Oct', 'Nov', 'Dec'];
+
+// 26 Feb 16:19:34
+function timestamp() {
+  var d = new Date();
+  var time = [pad(d.getHours()),
+              pad(d.getMinutes()),
+              pad(d.getSeconds())].join(':');
+  return [d.getDate(), months[d.getMonth()], time].join(' ');
+}
+
+
+// log is just a thin wrapper to console.log that prepends a timestamp
+exports.log = function() {
+  console.log('%s - %s', timestamp(), exports.format.apply(exports, arguments));
+};
+
+
+/**
+ * Inherit the prototype methods from one constructor into another.
+ *
+ * The Function.prototype.inherits from lang.js rewritten as a standalone
+ * function (not on Function.prototype). NOTE: If this file is to be loaded
+ * during bootstrapping this function needs to be rewritten using some native
+ * functions as prototype setup using normal JavaScript does not work as
+ * expected during bootstrapping (see mirror.js in r114903).
+ *
+ * @param {function} ctor Constructor function which needs to inherit the
+ *     prototype.
+ * @param {function} superCtor Constructor function to inherit prototype from.
+ */
+exports.inherits = require('inherits');
+
+exports._extend = function(origin, add) {
+  // Don't do anything if add isn't an object
+  if (!add || !isObject(add)) return origin;
+
+  var keys = Object.keys(add);
+  var i = keys.length;
+  while (i--) {
+    origin[keys[i]] = add[keys[i]];
+  }
+  return origin;
+};
+
+function hasOwnProperty(obj, prop) {
+  return Object.prototype.hasOwnProperty.call(obj, prop);
+}
+
+}).call(this,require('_process'),typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
+},{"./support/isBuffer":199,"_process":303,"inherits":198}],201:[function(require,module,exports){
 'use strict'
 
 exports.byteLength = byteLength
@@ -31488,7 +32444,7 @@ function fromByteArray (uint8) {
   return parts.join('')
 }
 
-},{}],196:[function(require,module,exports){
+},{}],202:[function(require,module,exports){
 (function (module, exports) {
   'use strict';
 
@@ -34917,7 +35873,7 @@ function fromByteArray (uint8) {
   };
 })(typeof module === 'undefined' || module, this);
 
-},{"buffer":198}],197:[function(require,module,exports){
+},{"buffer":204}],203:[function(require,module,exports){
 var r;
 
 module.exports = function rand(len) {
@@ -34984,43 +35940,43 @@ if (typeof self === 'object') {
   }
 }
 
-},{"crypto":198}],198:[function(require,module,exports){
+},{"crypto":204}],204:[function(require,module,exports){
 
-},{}],199:[function(require,module,exports){
+},{}],205:[function(require,module,exports){
 arguments[4][10][0].apply(exports,arguments)
-},{"dup":10,"safe-buffer":320}],200:[function(require,module,exports){
+},{"dup":10,"safe-buffer":326}],206:[function(require,module,exports){
 arguments[4][11][0].apply(exports,arguments)
-},{"./aes":199,"./ghash":204,"./incr32":205,"buffer-xor":226,"cipher-base":228,"dup":11,"inherits":279,"safe-buffer":320}],201:[function(require,module,exports){
+},{"./aes":205,"./ghash":210,"./incr32":211,"buffer-xor":232,"cipher-base":234,"dup":11,"inherits":285,"safe-buffer":326}],207:[function(require,module,exports){
 arguments[4][12][0].apply(exports,arguments)
-},{"./decrypter":202,"./encrypter":203,"./modes/list.json":213,"dup":12}],202:[function(require,module,exports){
+},{"./decrypter":208,"./encrypter":209,"./modes/list.json":219,"dup":12}],208:[function(require,module,exports){
 arguments[4][13][0].apply(exports,arguments)
-},{"./aes":199,"./authCipher":200,"./modes":212,"./streamCipher":215,"cipher-base":228,"dup":13,"evp_bytestokey":263,"inherits":279,"safe-buffer":320}],203:[function(require,module,exports){
+},{"./aes":205,"./authCipher":206,"./modes":218,"./streamCipher":221,"cipher-base":234,"dup":13,"evp_bytestokey":269,"inherits":285,"safe-buffer":326}],209:[function(require,module,exports){
 arguments[4][14][0].apply(exports,arguments)
-},{"./aes":199,"./authCipher":200,"./modes":212,"./streamCipher":215,"cipher-base":228,"dup":14,"evp_bytestokey":263,"inherits":279,"safe-buffer":320}],204:[function(require,module,exports){
+},{"./aes":205,"./authCipher":206,"./modes":218,"./streamCipher":221,"cipher-base":234,"dup":14,"evp_bytestokey":269,"inherits":285,"safe-buffer":326}],210:[function(require,module,exports){
 arguments[4][15][0].apply(exports,arguments)
-},{"dup":15,"safe-buffer":320}],205:[function(require,module,exports){
+},{"dup":15,"safe-buffer":326}],211:[function(require,module,exports){
 arguments[4][16][0].apply(exports,arguments)
-},{"dup":16}],206:[function(require,module,exports){
+},{"dup":16}],212:[function(require,module,exports){
 arguments[4][17][0].apply(exports,arguments)
-},{"buffer-xor":226,"dup":17}],207:[function(require,module,exports){
+},{"buffer-xor":232,"dup":17}],213:[function(require,module,exports){
 arguments[4][18][0].apply(exports,arguments)
-},{"buffer-xor":226,"dup":18,"safe-buffer":320}],208:[function(require,module,exports){
+},{"buffer-xor":232,"dup":18,"safe-buffer":326}],214:[function(require,module,exports){
 arguments[4][19][0].apply(exports,arguments)
-},{"dup":19,"safe-buffer":320}],209:[function(require,module,exports){
+},{"dup":19,"safe-buffer":326}],215:[function(require,module,exports){
 arguments[4][20][0].apply(exports,arguments)
-},{"dup":20,"safe-buffer":320}],210:[function(require,module,exports){
+},{"dup":20,"safe-buffer":326}],216:[function(require,module,exports){
 arguments[4][21][0].apply(exports,arguments)
-},{"../incr32":205,"buffer-xor":226,"dup":21,"safe-buffer":320}],211:[function(require,module,exports){
+},{"../incr32":211,"buffer-xor":232,"dup":21,"safe-buffer":326}],217:[function(require,module,exports){
 arguments[4][22][0].apply(exports,arguments)
-},{"dup":22}],212:[function(require,module,exports){
+},{"dup":22}],218:[function(require,module,exports){
 arguments[4][23][0].apply(exports,arguments)
-},{"./cbc":206,"./cfb":207,"./cfb1":208,"./cfb8":209,"./ctr":210,"./ecb":211,"./list.json":213,"./ofb":214,"dup":23}],213:[function(require,module,exports){
+},{"./cbc":212,"./cfb":213,"./cfb1":214,"./cfb8":215,"./ctr":216,"./ecb":217,"./list.json":219,"./ofb":220,"dup":23}],219:[function(require,module,exports){
 arguments[4][24][0].apply(exports,arguments)
-},{"dup":24}],214:[function(require,module,exports){
+},{"dup":24}],220:[function(require,module,exports){
 arguments[4][25][0].apply(exports,arguments)
-},{"buffer":227,"buffer-xor":226,"dup":25}],215:[function(require,module,exports){
+},{"buffer":233,"buffer-xor":232,"dup":25}],221:[function(require,module,exports){
 arguments[4][26][0].apply(exports,arguments)
-},{"./aes":199,"cipher-base":228,"dup":26,"inherits":279,"safe-buffer":320}],216:[function(require,module,exports){
+},{"./aes":205,"cipher-base":234,"dup":26,"inherits":285,"safe-buffer":326}],222:[function(require,module,exports){
 var DES = require('browserify-des')
 var aes = require('browserify-aes/browser')
 var aesModes = require('browserify-aes/modes')
@@ -35089,11 +36045,11 @@ exports.createDecipher = exports.Decipher = createDecipher
 exports.createDecipheriv = exports.Decipheriv = createDecipheriv
 exports.listCiphers = exports.getCiphers = getCiphers
 
-},{"browserify-aes/browser":201,"browserify-aes/modes":212,"browserify-des":217,"browserify-des/modes":218,"evp_bytestokey":263}],217:[function(require,module,exports){
-(function (Buffer){
+},{"browserify-aes/browser":207,"browserify-aes/modes":218,"browserify-des":223,"browserify-des/modes":224,"evp_bytestokey":269}],223:[function(require,module,exports){
 var CipherBase = require('cipher-base')
 var des = require('des.js')
 var inherits = require('inherits')
+var Buffer = require('safe-buffer').Buffer
 
 var modes = {
   'des-ede3-cbc': des.CBC.instantiate(des.EDE),
@@ -35118,10 +36074,16 @@ function DES (opts) {
     type = 'encrypt'
   }
   var key = opts.key
+  if (!Buffer.isBuffer(key)) {
+    key = Buffer.from(key)
+  }
   if (modeName === 'des-ede' || modeName === 'des-ede-cbc') {
     key = Buffer.concat([key, key.slice(0, 8)])
   }
   var iv = opts.iv
+  if (!Buffer.isBuffer(iv)) {
+    iv = Buffer.from(iv)
+  }
   this._des = mode.create({
     key: key,
     iv: iv,
@@ -35129,14 +36091,13 @@ function DES (opts) {
   })
 }
 DES.prototype._update = function (data) {
-  return new Buffer(this._des.update(data))
+  return Buffer.from(this._des.update(data))
 }
 DES.prototype._final = function () {
-  return new Buffer(this._des.final())
+  return Buffer.from(this._des.final())
 }
 
-}).call(this,require("buffer").Buffer)
-},{"buffer":227,"cipher-base":228,"des.js":236,"inherits":279}],218:[function(require,module,exports){
+},{"cipher-base":234,"des.js":242,"inherits":285,"safe-buffer":326}],224:[function(require,module,exports){
 exports['des-ecb'] = {
   key: 8,
   iv: 0
@@ -35162,7 +36123,7 @@ exports['des-ede'] = {
   iv: 0
 }
 
-},{}],219:[function(require,module,exports){
+},{}],225:[function(require,module,exports){
 (function (Buffer){
 var bn = require('bn.js');
 var randomBytes = require('randombytes');
@@ -35206,10 +36167,10 @@ function getr(priv) {
 }
 
 }).call(this,require("buffer").Buffer)
-},{"bn.js":196,"buffer":227,"randombytes":304}],220:[function(require,module,exports){
+},{"bn.js":202,"buffer":233,"randombytes":310}],226:[function(require,module,exports){
 module.exports = require('./browser/algorithms.json')
 
-},{"./browser/algorithms.json":221}],221:[function(require,module,exports){
+},{"./browser/algorithms.json":227}],227:[function(require,module,exports){
 module.exports={
   "sha224WithRSAEncryption": {
     "sign": "rsa",
@@ -35363,7 +36324,7 @@ module.exports={
   }
 }
 
-},{}],222:[function(require,module,exports){
+},{}],228:[function(require,module,exports){
 module.exports={
   "1.3.132.0.10": "secp256k1",
   "1.3.132.0.33": "p224",
@@ -35373,7 +36334,7 @@ module.exports={
   "1.3.132.0.35": "p521"
 }
 
-},{}],223:[function(require,module,exports){
+},{}],229:[function(require,module,exports){
 (function (Buffer){
 var createHash = require('create-hash')
 var stream = require('stream')
@@ -35468,7 +36429,7 @@ module.exports = {
 }
 
 }).call(this,require("buffer").Buffer)
-},{"./algorithms.json":221,"./sign":224,"./verify":225,"buffer":227,"create-hash":231,"inherits":279,"stream":329}],224:[function(require,module,exports){
+},{"./algorithms.json":227,"./sign":230,"./verify":231,"buffer":233,"create-hash":237,"inherits":285,"stream":335}],230:[function(require,module,exports){
 (function (Buffer){
 // much of this based on https://github.com/indutny/self-signed/blob/gh-pages/lib/rsa.js
 var createHmac = require('create-hmac')
@@ -35617,7 +36578,7 @@ module.exports.getKey = getKey
 module.exports.makeKey = makeKey
 
 }).call(this,require("buffer").Buffer)
-},{"./curves.json":222,"bn.js":196,"browserify-rsa":219,"buffer":227,"create-hmac":233,"elliptic":246,"parse-asn1":290}],225:[function(require,module,exports){
+},{"./curves.json":228,"bn.js":202,"browserify-rsa":225,"buffer":233,"create-hmac":239,"elliptic":252,"parse-asn1":296}],231:[function(require,module,exports){
 (function (Buffer){
 // much of this based on https://github.com/indutny/self-signed/blob/gh-pages/lib/rsa.js
 var BN = require('bn.js')
@@ -35704,9 +36665,9 @@ function checkValue (b, q) {
 module.exports = verify
 
 }).call(this,require("buffer").Buffer)
-},{"./curves.json":222,"bn.js":196,"buffer":227,"elliptic":246,"parse-asn1":290}],226:[function(require,module,exports){
+},{"./curves.json":228,"bn.js":202,"buffer":233,"elliptic":252,"parse-asn1":296}],232:[function(require,module,exports){
 arguments[4][28][0].apply(exports,arguments)
-},{"buffer":227,"dup":28}],227:[function(require,module,exports){
+},{"buffer":233,"dup":28}],233:[function(require,module,exports){
 /*!
  * The buffer module from node.js, for the browser.
  *
@@ -35755,7 +36716,7 @@ function typedArraySupport () {
   // Can typed array instances can be augmented?
   try {
     var arr = new Uint8Array(1)
-    arr.__proto__ = {__proto__: Uint8Array.prototype, foo: function () { return 42 }}
+    arr.__proto__ = { __proto__: Uint8Array.prototype, foo: function () { return 42 } }
     return arr.foo() === 42
   } catch (e) {
     return false
@@ -35763,26 +36724,24 @@ function typedArraySupport () {
 }
 
 Object.defineProperty(Buffer.prototype, 'parent', {
+  enumerable: true,
   get: function () {
-    if (!(this instanceof Buffer)) {
-      return undefined
-    }
+    if (!Buffer.isBuffer(this)) return undefined
     return this.buffer
   }
 })
 
 Object.defineProperty(Buffer.prototype, 'offset', {
+  enumerable: true,
   get: function () {
-    if (!(this instanceof Buffer)) {
-      return undefined
-    }
+    if (!Buffer.isBuffer(this)) return undefined
     return this.byteOffset
   }
 })
 
 function createBuffer (length) {
   if (length > K_MAX_LENGTH) {
-    throw new RangeError('Invalid typed array length')
+    throw new RangeError('The value "' + length + '" is invalid for option "size"')
   }
   // Return an augmented `Uint8Array` instance
   var buf = new Uint8Array(length)
@@ -35804,8 +36763,8 @@ function Buffer (arg, encodingOrOffset, length) {
   // Common case.
   if (typeof arg === 'number') {
     if (typeof encodingOrOffset === 'string') {
-      throw new Error(
-        'If encoding is specified then the first argument must be a string'
+      throw new TypeError(
+        'The "string" argument must be of type string. Received type number'
       )
     }
     return allocUnsafe(arg)
@@ -35814,7 +36773,7 @@ function Buffer (arg, encodingOrOffset, length) {
 }
 
 // Fix subarray() in ES2016. See: https://github.com/feross/buffer/pull/97
-if (typeof Symbol !== 'undefined' && Symbol.species &&
+if (typeof Symbol !== 'undefined' && Symbol.species != null &&
     Buffer[Symbol.species] === Buffer) {
   Object.defineProperty(Buffer, Symbol.species, {
     value: null,
@@ -35827,19 +36786,51 @@ if (typeof Symbol !== 'undefined' && Symbol.species &&
 Buffer.poolSize = 8192 // not used by this implementation
 
 function from (value, encodingOrOffset, length) {
-  if (typeof value === 'number') {
-    throw new TypeError('"value" argument must not be a number')
-  }
-
-  if (isArrayBuffer(value) || (value && isArrayBuffer(value.buffer))) {
-    return fromArrayBuffer(value, encodingOrOffset, length)
-  }
-
   if (typeof value === 'string') {
     return fromString(value, encodingOrOffset)
   }
 
-  return fromObject(value)
+  if (ArrayBuffer.isView(value)) {
+    return fromArrayLike(value)
+  }
+
+  if (value == null) {
+    throw TypeError(
+      'The first argument must be one of type string, Buffer, ArrayBuffer, Array, ' +
+      'or Array-like Object. Received type ' + (typeof value)
+    )
+  }
+
+  if (isInstance(value, ArrayBuffer) ||
+      (value && isInstance(value.buffer, ArrayBuffer))) {
+    return fromArrayBuffer(value, encodingOrOffset, length)
+  }
+
+  if (typeof value === 'number') {
+    throw new TypeError(
+      'The "value" argument must not be of type number. Received type number'
+    )
+  }
+
+  var valueOf = value.valueOf && value.valueOf()
+  if (valueOf != null && valueOf !== value) {
+    return Buffer.from(valueOf, encodingOrOffset, length)
+  }
+
+  var b = fromObject(value)
+  if (b) return b
+
+  if (typeof Symbol !== 'undefined' && Symbol.toPrimitive != null &&
+      typeof value[Symbol.toPrimitive] === 'function') {
+    return Buffer.from(
+      value[Symbol.toPrimitive]('string'), encodingOrOffset, length
+    )
+  }
+
+  throw new TypeError(
+    'The first argument must be one of type string, Buffer, ArrayBuffer, Array, ' +
+    'or Array-like Object. Received type ' + (typeof value)
+  )
 }
 
 /**
@@ -35863,7 +36854,7 @@ function assertSize (size) {
   if (typeof size !== 'number') {
     throw new TypeError('"size" argument must be of type number')
   } else if (size < 0) {
-    throw new RangeError('"size" argument must not be negative')
+    throw new RangeError('The value "' + size + '" is invalid for option "size"')
   }
 }
 
@@ -35978,20 +36969,16 @@ function fromObject (obj) {
     return buf
   }
 
-  if (obj) {
-    if (ArrayBuffer.isView(obj) || 'length' in obj) {
-      if (typeof obj.length !== 'number' || numberIsNaN(obj.length)) {
-        return createBuffer(0)
-      }
-      return fromArrayLike(obj)
+  if (obj.length !== undefined) {
+    if (typeof obj.length !== 'number' || numberIsNaN(obj.length)) {
+      return createBuffer(0)
     }
-
-    if (obj.type === 'Buffer' && Array.isArray(obj.data)) {
-      return fromArrayLike(obj.data)
-    }
+    return fromArrayLike(obj)
   }
 
-  throw new TypeError('The first argument must be one of type string, Buffer, ArrayBuffer, Array, or Array-like Object.')
+  if (obj.type === 'Buffer' && Array.isArray(obj.data)) {
+    return fromArrayLike(obj.data)
+  }
 }
 
 function checked (length) {
@@ -36012,12 +36999,17 @@ function SlowBuffer (length) {
 }
 
 Buffer.isBuffer = function isBuffer (b) {
-  return b != null && b._isBuffer === true
+  return b != null && b._isBuffer === true &&
+    b !== Buffer.prototype // so Buffer.isBuffer(Buffer.prototype) will be false
 }
 
 Buffer.compare = function compare (a, b) {
+  if (isInstance(a, Uint8Array)) a = Buffer.from(a, a.offset, a.byteLength)
+  if (isInstance(b, Uint8Array)) b = Buffer.from(b, b.offset, b.byteLength)
   if (!Buffer.isBuffer(a) || !Buffer.isBuffer(b)) {
-    throw new TypeError('Arguments must be Buffers')
+    throw new TypeError(
+      'The "buf1", "buf2" arguments must be one of type Buffer or Uint8Array'
+    )
   }
 
   if (a === b) return 0
@@ -36078,7 +37070,7 @@ Buffer.concat = function concat (list, length) {
   var pos = 0
   for (i = 0; i < list.length; ++i) {
     var buf = list[i]
-    if (ArrayBuffer.isView(buf)) {
+    if (isInstance(buf, Uint8Array)) {
       buf = Buffer.from(buf)
     }
     if (!Buffer.isBuffer(buf)) {
@@ -36094,15 +37086,19 @@ function byteLength (string, encoding) {
   if (Buffer.isBuffer(string)) {
     return string.length
   }
-  if (ArrayBuffer.isView(string) || isArrayBuffer(string)) {
+  if (ArrayBuffer.isView(string) || isInstance(string, ArrayBuffer)) {
     return string.byteLength
   }
   if (typeof string !== 'string') {
-    string = '' + string
+    throw new TypeError(
+      'The "string" argument must be one of type string, Buffer, or ArrayBuffer. ' +
+      'Received type ' + typeof string
+    )
   }
 
   var len = string.length
-  if (len === 0) return 0
+  var mustMatch = (arguments.length > 2 && arguments[2] === true)
+  if (!mustMatch && len === 0) return 0
 
   // Use a for loop to avoid recursion
   var loweredCase = false
@@ -36114,7 +37110,6 @@ function byteLength (string, encoding) {
         return len
       case 'utf8':
       case 'utf-8':
-      case undefined:
         return utf8ToBytes(string).length
       case 'ucs2':
       case 'ucs-2':
@@ -36126,7 +37121,9 @@ function byteLength (string, encoding) {
       case 'base64':
         return base64ToBytes(string).length
       default:
-        if (loweredCase) return utf8ToBytes(string).length // assume utf8
+        if (loweredCase) {
+          return mustMatch ? -1 : utf8ToBytes(string).length // assume utf8
+        }
         encoding = ('' + encoding).toLowerCase()
         loweredCase = true
     }
@@ -36273,16 +37270,20 @@ Buffer.prototype.equals = function equals (b) {
 Buffer.prototype.inspect = function inspect () {
   var str = ''
   var max = exports.INSPECT_MAX_BYTES
-  if (this.length > 0) {
-    str = this.toString('hex', 0, max).match(/.{2}/g).join(' ')
-    if (this.length > max) str += ' ... '
-  }
+  str = this.toString('hex', 0, max).replace(/(.{2})/g, '$1 ').trim()
+  if (this.length > max) str += ' ... '
   return '<Buffer ' + str + '>'
 }
 
 Buffer.prototype.compare = function compare (target, start, end, thisStart, thisEnd) {
+  if (isInstance(target, Uint8Array)) {
+    target = Buffer.from(target, target.offset, target.byteLength)
+  }
   if (!Buffer.isBuffer(target)) {
-    throw new TypeError('Argument must be a Buffer')
+    throw new TypeError(
+      'The "target" argument must be one of type Buffer or Uint8Array. ' +
+      'Received type ' + (typeof target)
+    )
   }
 
   if (start === undefined) {
@@ -36361,7 +37362,7 @@ function bidirectionalIndexOf (buffer, val, byteOffset, encoding, dir) {
   } else if (byteOffset < -0x80000000) {
     byteOffset = -0x80000000
   }
-  byteOffset = +byteOffset  // Coerce to Number.
+  byteOffset = +byteOffset // Coerce to Number.
   if (numberIsNaN(byteOffset)) {
     // byteOffset: it it's undefined, null, NaN, "foo", etc, search whole buffer
     byteOffset = dir ? 0 : (buffer.length - 1)
@@ -36613,8 +37614,8 @@ function utf8Slice (buf, start, end) {
     var codePoint = null
     var bytesPerSequence = (firstByte > 0xEF) ? 4
       : (firstByte > 0xDF) ? 3
-      : (firstByte > 0xBF) ? 2
-      : 1
+        : (firstByte > 0xBF) ? 2
+          : 1
 
     if (i + bytesPerSequence <= end) {
       var secondByte, thirdByte, fourthByte, tempCodePoint
@@ -37277,7 +38278,7 @@ Buffer.prototype.fill = function fill (val, start, end, encoding) {
   } else {
     var bytes = Buffer.isBuffer(val)
       ? val
-      : new Buffer(val, encoding)
+      : Buffer.from(val, encoding)
     var len = bytes.length
     if (len === 0) {
       throw new TypeError('The value "' + val +
@@ -37432,21 +38433,22 @@ function blitBuffer (src, dst, offset, length) {
   return i
 }
 
-// ArrayBuffers from another context (i.e. an iframe) do not pass the `instanceof` check
-// but they should be treated as valid. See: https://github.com/feross/buffer/issues/166
-function isArrayBuffer (obj) {
-  return obj instanceof ArrayBuffer ||
-    (obj != null && obj.constructor != null && obj.constructor.name === 'ArrayBuffer' &&
-      typeof obj.byteLength === 'number')
+// ArrayBuffer or Uint8Array objects from other contexts (i.e. iframes) do not pass
+// the `instanceof` check but they should be treated as of that type.
+// See: https://github.com/feross/buffer/issues/166
+function isInstance (obj, type) {
+  return obj instanceof type ||
+    (obj != null && obj.constructor != null && obj.constructor.name != null &&
+      obj.constructor.name === type.name)
 }
-
 function numberIsNaN (obj) {
+  // For IE11 support
   return obj !== obj // eslint-disable-line no-self-compare
 }
 
-},{"base64-js":195,"ieee754":278}],228:[function(require,module,exports){
+},{"base64-js":201,"ieee754":284}],234:[function(require,module,exports){
 arguments[4][30][0].apply(exports,arguments)
-},{"dup":30,"inherits":279,"safe-buffer":320,"stream":329,"string_decoder":330}],229:[function(require,module,exports){
+},{"dup":30,"inherits":285,"safe-buffer":326,"stream":335,"string_decoder":336}],235:[function(require,module,exports){
 (function (Buffer){
 // Copyright Joyent, Inc. and other Node contributors.
 //
@@ -37557,141 +38559,143 @@ function objectToString(o) {
 }
 
 }).call(this,{"isBuffer":require("../../is-buffer/index.js")})
-},{"../../is-buffer/index.js":280}],230:[function(require,module,exports){
+},{"../../is-buffer/index.js":286}],236:[function(require,module,exports){
 (function (Buffer){
-var elliptic = require('elliptic');
-var BN = require('bn.js');
+var elliptic = require('elliptic')
+var BN = require('bn.js')
 
-module.exports = function createECDH(curve) {
-	return new ECDH(curve);
-};
+module.exports = function createECDH (curve) {
+  return new ECDH(curve)
+}
 
 var aliases = {
-	secp256k1: {
-		name: 'secp256k1',
-		byteLength: 32
-	},
-	secp224r1: {
-		name: 'p224',
-		byteLength: 28
-	},
-	prime256v1: {
-		name: 'p256',
-		byteLength: 32
-	},
-	prime192v1: {
-		name: 'p192',
-		byteLength: 24
-	},
-	ed25519: {
-		name: 'ed25519',
-		byteLength: 32
-	},
-	secp384r1: {
-		name: 'p384',
-		byteLength: 48
-	},
-	secp521r1: {
-		name: 'p521',
-		byteLength: 66
-	}
-};
+  secp256k1: {
+    name: 'secp256k1',
+    byteLength: 32
+  },
+  secp224r1: {
+    name: 'p224',
+    byteLength: 28
+  },
+  prime256v1: {
+    name: 'p256',
+    byteLength: 32
+  },
+  prime192v1: {
+    name: 'p192',
+    byteLength: 24
+  },
+  ed25519: {
+    name: 'ed25519',
+    byteLength: 32
+  },
+  secp384r1: {
+    name: 'p384',
+    byteLength: 48
+  },
+  secp521r1: {
+    name: 'p521',
+    byteLength: 66
+  }
+}
 
-aliases.p224 = aliases.secp224r1;
-aliases.p256 = aliases.secp256r1 = aliases.prime256v1;
-aliases.p192 = aliases.secp192r1 = aliases.prime192v1;
-aliases.p384 = aliases.secp384r1;
-aliases.p521 = aliases.secp521r1;
+aliases.p224 = aliases.secp224r1
+aliases.p256 = aliases.secp256r1 = aliases.prime256v1
+aliases.p192 = aliases.secp192r1 = aliases.prime192v1
+aliases.p384 = aliases.secp384r1
+aliases.p521 = aliases.secp521r1
 
-function ECDH(curve) {
-	this.curveType = aliases[curve];
-	if (!this.curveType ) {
-		this.curveType = {
-			name: curve
-		};
-	}
-	this.curve = new elliptic.ec(this.curveType.name);
-	this.keys = void 0;
+function ECDH (curve) {
+  this.curveType = aliases[curve]
+  if (!this.curveType) {
+    this.curveType = {
+      name: curve
+    }
+  }
+  this.curve = new elliptic.ec(this.curveType.name) // eslint-disable-line new-cap
+  this.keys = void 0
 }
 
 ECDH.prototype.generateKeys = function (enc, format) {
-	this.keys = this.curve.genKeyPair();
-	return this.getPublicKey(enc, format);
-};
+  this.keys = this.curve.genKeyPair()
+  return this.getPublicKey(enc, format)
+}
 
 ECDH.prototype.computeSecret = function (other, inenc, enc) {
-	inenc = inenc || 'utf8';
-	if (!Buffer.isBuffer(other)) {
-		other = new Buffer(other, inenc);
-	}
-	var otherPub = this.curve.keyFromPublic(other).getPublic();
-	var out = otherPub.mul(this.keys.getPrivate()).getX();
-	return formatReturnValue(out, enc, this.curveType.byteLength);
-};
+  inenc = inenc || 'utf8'
+  if (!Buffer.isBuffer(other)) {
+    other = new Buffer(other, inenc)
+  }
+  var otherPub = this.curve.keyFromPublic(other).getPublic()
+  var out = otherPub.mul(this.keys.getPrivate()).getX()
+  return formatReturnValue(out, enc, this.curveType.byteLength)
+}
 
 ECDH.prototype.getPublicKey = function (enc, format) {
-	var key = this.keys.getPublic(format === 'compressed', true);
-	if (format === 'hybrid') {
-		if (key[key.length - 1] % 2) {
-			key[0] = 7;
-		} else {
-			key [0] = 6;
-		}
-	}
-	return formatReturnValue(key, enc);
-};
+  var key = this.keys.getPublic(format === 'compressed', true)
+  if (format === 'hybrid') {
+    if (key[key.length - 1] % 2) {
+      key[0] = 7
+    } else {
+      key[0] = 6
+    }
+  }
+  return formatReturnValue(key, enc)
+}
 
 ECDH.prototype.getPrivateKey = function (enc) {
-	return formatReturnValue(this.keys.getPrivate(), enc);
-};
+  return formatReturnValue(this.keys.getPrivate(), enc)
+}
 
 ECDH.prototype.setPublicKey = function (pub, enc) {
-	enc = enc || 'utf8';
-	if (!Buffer.isBuffer(pub)) {
-		pub = new Buffer(pub, enc);
-	}
-	this.keys._importPublic(pub);
-	return this;
-};
+  enc = enc || 'utf8'
+  if (!Buffer.isBuffer(pub)) {
+    pub = new Buffer(pub, enc)
+  }
+  this.keys._importPublic(pub)
+  return this
+}
 
 ECDH.prototype.setPrivateKey = function (priv, enc) {
-	enc = enc || 'utf8';
-	if (!Buffer.isBuffer(priv)) {
-		priv = new Buffer(priv, enc);
-	}
-	var _priv = new BN(priv);
-	_priv = _priv.toString(16);
-	this.keys._importPrivate(_priv);
-	return this;
-};
+  enc = enc || 'utf8'
+  if (!Buffer.isBuffer(priv)) {
+    priv = new Buffer(priv, enc)
+  }
 
-function formatReturnValue(bn, enc, len) {
-	if (!Array.isArray(bn)) {
-		bn = bn.toArray();
-	}
-	var buf = new Buffer(bn);
-	if (len && buf.length < len) {
-		var zeros = new Buffer(len - buf.length);
-		zeros.fill(0);
-		buf = Buffer.concat([zeros, buf]);
-	}
-	if (!enc) {
-		return buf;
-	} else {
-		return buf.toString(enc);
-	}
+  var _priv = new BN(priv)
+  _priv = _priv.toString(16)
+  this.keys = this.curve.genKeyPair()
+  this.keys._importPrivate(_priv)
+  return this
+}
+
+function formatReturnValue (bn, enc, len) {
+  if (!Array.isArray(bn)) {
+    bn = bn.toArray()
+  }
+  var buf = new Buffer(bn)
+  if (len && buf.length < len) {
+    var zeros = new Buffer(len - buf.length)
+    zeros.fill(0)
+    buf = Buffer.concat([zeros, buf])
+  }
+  if (!enc) {
+    return buf
+  } else {
+    return buf.toString(enc)
+  }
 }
 
 }).call(this,require("buffer").Buffer)
-},{"bn.js":196,"buffer":227,"elliptic":246}],231:[function(require,module,exports){
+},{"bn.js":202,"buffer":233,"elliptic":252}],237:[function(require,module,exports){
 arguments[4][31][0].apply(exports,arguments)
-},{"cipher-base":228,"dup":31,"inherits":279,"md5.js":282,"ripemd160":319,"sha.js":322}],232:[function(require,module,exports){
+},{"cipher-base":234,"dup":31,"inherits":285,"md5.js":288,"ripemd160":325,"sha.js":328}],238:[function(require,module,exports){
 arguments[4][32][0].apply(exports,arguments)
-},{"dup":32,"md5.js":282}],233:[function(require,module,exports){
+},{"dup":32,"md5.js":288}],239:[function(require,module,exports){
 arguments[4][33][0].apply(exports,arguments)
-},{"./legacy":234,"cipher-base":228,"create-hash/md5":232,"dup":33,"inherits":279,"ripemd160":319,"safe-buffer":320,"sha.js":322}],234:[function(require,module,exports){
+},{"./legacy":240,"cipher-base":234,"create-hash/md5":238,"dup":33,"inherits":285,"ripemd160":325,"safe-buffer":326,"sha.js":328}],240:[function(require,module,exports){
 arguments[4][34][0].apply(exports,arguments)
-},{"cipher-base":228,"dup":34,"inherits":279,"safe-buffer":320}],235:[function(require,module,exports){
+},{"cipher-base":234,"dup":34,"inherits":285,"safe-buffer":326}],241:[function(require,module,exports){
 'use strict'
 
 exports.randomBytes = exports.rng = exports.pseudoRandomBytes = exports.prng = require('randombytes')
@@ -37790,7 +38794,7 @@ exports.constants = {
   'POINT_CONVERSION_HYBRID': 6
 }
 
-},{"browserify-cipher":216,"browserify-sign":223,"browserify-sign/algos":220,"create-ecdh":230,"create-hash":231,"create-hmac":233,"diffie-hellman":242,"pbkdf2":291,"public-encrypt":298,"randombytes":304,"randomfill":305}],236:[function(require,module,exports){
+},{"browserify-cipher":222,"browserify-sign":229,"browserify-sign/algos":226,"create-ecdh":236,"create-hash":237,"create-hmac":239,"diffie-hellman":248,"pbkdf2":297,"public-encrypt":304,"randombytes":310,"randomfill":311}],242:[function(require,module,exports){
 'use strict';
 
 exports.utils = require('./des/utils');
@@ -37799,7 +38803,7 @@ exports.DES = require('./des/des');
 exports.CBC = require('./des/cbc');
 exports.EDE = require('./des/ede');
 
-},{"./des/cbc":237,"./des/cipher":238,"./des/des":239,"./des/ede":240,"./des/utils":241}],237:[function(require,module,exports){
+},{"./des/cbc":243,"./des/cipher":244,"./des/des":245,"./des/ede":246,"./des/utils":247}],243:[function(require,module,exports){
 'use strict';
 
 var assert = require('minimalistic-assert');
@@ -37866,7 +38870,7 @@ proto._update = function _update(inp, inOff, out, outOff) {
   }
 };
 
-},{"inherits":279,"minimalistic-assert":284}],238:[function(require,module,exports){
+},{"inherits":285,"minimalistic-assert":290}],244:[function(require,module,exports){
 'use strict';
 
 var assert = require('minimalistic-assert');
@@ -38009,7 +39013,7 @@ Cipher.prototype._finalDecrypt = function _finalDecrypt() {
   return this._unpad(out);
 };
 
-},{"minimalistic-assert":284}],239:[function(require,module,exports){
+},{"minimalistic-assert":290}],245:[function(require,module,exports){
 'use strict';
 
 var assert = require('minimalistic-assert');
@@ -38154,7 +39158,7 @@ DES.prototype._decrypt = function _decrypt(state, lStart, rStart, out, off) {
   utils.rip(l, r, out, off);
 };
 
-},{"../des":236,"inherits":279,"minimalistic-assert":284}],240:[function(require,module,exports){
+},{"../des":242,"inherits":285,"minimalistic-assert":290}],246:[function(require,module,exports){
 'use strict';
 
 var assert = require('minimalistic-assert');
@@ -38211,7 +39215,7 @@ EDE.prototype._update = function _update(inp, inOff, out, outOff) {
 EDE.prototype._pad = DES.prototype._pad;
 EDE.prototype._unpad = DES.prototype._unpad;
 
-},{"../des":236,"inherits":279,"minimalistic-assert":284}],241:[function(require,module,exports){
+},{"../des":242,"inherits":285,"minimalistic-assert":290}],247:[function(require,module,exports){
 'use strict';
 
 exports.readUInt32BE = function readUInt32BE(bytes, off) {
@@ -38469,7 +39473,7 @@ exports.padSplit = function padSplit(num, size, group) {
   return out.join(' ');
 };
 
-},{}],242:[function(require,module,exports){
+},{}],248:[function(require,module,exports){
 (function (Buffer){
 var generatePrime = require('./lib/generatePrime')
 var primes = require('./lib/primes.json')
@@ -38515,7 +39519,7 @@ exports.DiffieHellmanGroup = exports.createDiffieHellmanGroup = exports.getDiffi
 exports.createDiffieHellman = exports.DiffieHellman = createDiffieHellman
 
 }).call(this,require("buffer").Buffer)
-},{"./lib/dh":243,"./lib/generatePrime":244,"./lib/primes.json":245,"buffer":227}],243:[function(require,module,exports){
+},{"./lib/dh":249,"./lib/generatePrime":250,"./lib/primes.json":251,"buffer":233}],249:[function(require,module,exports){
 (function (Buffer){
 var BN = require('bn.js');
 var MillerRabin = require('miller-rabin');
@@ -38683,7 +39687,7 @@ function formatReturnValue(bn, enc) {
 }
 
 }).call(this,require("buffer").Buffer)
-},{"./generatePrime":244,"bn.js":196,"buffer":227,"miller-rabin":283,"randombytes":304}],244:[function(require,module,exports){
+},{"./generatePrime":250,"bn.js":202,"buffer":233,"miller-rabin":289,"randombytes":310}],250:[function(require,module,exports){
 var randomBytes = require('randombytes');
 module.exports = findPrime;
 findPrime.simpleSieve = simpleSieve;
@@ -38790,7 +39794,7 @@ function findPrime(bits, gen) {
 
 }
 
-},{"bn.js":196,"miller-rabin":283,"randombytes":304}],245:[function(require,module,exports){
+},{"bn.js":202,"miller-rabin":289,"randombytes":310}],251:[function(require,module,exports){
 module.exports={
     "modp1": {
         "gen": "02",
@@ -38825,7 +39829,7 @@ module.exports={
         "prime": "ffffffffffffffffc90fdaa22168c234c4c6628b80dc1cd129024e088a67cc74020bbea63b139b22514a08798e3404ddef9519b3cd3a431b302b0a6df25f14374fe1356d6d51c245e485b576625e7ec6f44c42e9a637ed6b0bff5cb6f406b7edee386bfb5a899fa5ae9f24117c4b1fe649286651ece45b3dc2007cb8a163bf0598da48361c55d39a69163fa8fd24cf5f83655d23dca3ad961c62f356208552bb9ed529077096966d670c354e4abc9804f1746c08ca18217c32905e462e36ce3be39e772c180e86039b2783a2ec07a28fb5c55df06f4c52c9de2bcbf6955817183995497cea956ae515d2261898fa051015728e5a8aaac42dad33170d04507a33a85521abdf1cba64ecfb850458dbef0a8aea71575d060c7db3970f85a6e1e4c7abf5ae8cdb0933d71e8c94e04a25619dcee3d2261ad2ee6bf12ffa06d98a0864d87602733ec86a64521f2b18177b200cbbe117577a615d6c770988c0bad946e208e24fa074e5ab3143db5bfce0fd108e4b82d120a92108011a723c12a787e6d788719a10bdba5b2699c327186af4e23c1a946834b6150bda2583e9ca2ad44ce8dbbbc2db04de8ef92e8efc141fbecaa6287c59474e6bc05d99b2964fa090c3a2233ba186515be7ed1f612970cee2d7afb81bdd762170481cd0069127d5b05aa993b4ea988d8fddc186ffb7dc90a6c08f4df435c93402849236c3fab4d27c7026c1d4dcb2602646dec9751e763dba37bdf8ff9406ad9e530ee5db382f413001aeb06a53ed9027d831179727b0865a8918da3edbebcf9b14ed44ce6cbaced4bb1bdb7f1447e6cc254b332051512bd7af426fb8f401378cd2bf5983ca01c64b92ecf032ea15d1721d03f482d7ce6e74fef6d55e702f46980c82b5a84031900b1c9e59e7c97fbec7e8f323a97a7e36cc88be0f1d45b7ff585ac54bd407b22b4154aacc8f6d7ebf48e1d814cc5ed20f8037e0a79715eef29be32806a1d58bb7c5da76f550aa3d8a1fbff0eb19ccb1a313d55cda56c9ec2ef29632387fe8d76e3c0468043e8f663f4860ee12bf2d5b0b7474d6e694f91e6dbe115974a3926f12fee5e438777cb6a932df8cd8bec4d073b931ba3bc832b68d9dd300741fa7bf8afc47ed2576f6936ba424663aab639c5ae4f5683423b4742bf1c978238f16cbe39d652de3fdb8befc848ad922222e04a4037c0713eb57a81a23f0c73473fc646cea306b4bcbc8862f8385ddfa9d4b7fa2c087e879683303ed5bdd3a062b3cf5b3a278a66d2a13f83f44f82ddf310ee074ab6a364597e899a0255dc164f31cc50846851df9ab48195ded7ea1b1d510bd7ee74d73faf36bc31ecfa268359046f4eb879f924009438b481c6cd7889a002ed5ee382bc9190da6fc026e479558e4475677e9aa9e3050e2765694dfc81f56e880b96e7160c980dd98edd3dfffffffffffffffff"
     }
 }
-},{}],246:[function(require,module,exports){
+},{}],252:[function(require,module,exports){
 'use strict';
 
 var elliptic = exports;
@@ -38840,7 +39844,7 @@ elliptic.curves = require('./elliptic/curves');
 elliptic.ec = require('./elliptic/ec');
 elliptic.eddsa = require('./elliptic/eddsa');
 
-},{"../package.json":261,"./elliptic/curve":249,"./elliptic/curves":252,"./elliptic/ec":253,"./elliptic/eddsa":256,"./elliptic/utils":260,"brorand":197}],247:[function(require,module,exports){
+},{"../package.json":267,"./elliptic/curve":255,"./elliptic/curves":258,"./elliptic/ec":259,"./elliptic/eddsa":262,"./elliptic/utils":266,"brorand":203}],253:[function(require,module,exports){
 'use strict';
 
 var BN = require('bn.js');
@@ -39217,7 +40221,7 @@ BasePoint.prototype.dblp = function dblp(k) {
   return r;
 };
 
-},{"../../elliptic":246,"bn.js":196}],248:[function(require,module,exports){
+},{"../../elliptic":252,"bn.js":202}],254:[function(require,module,exports){
 'use strict';
 
 var curve = require('../curve');
@@ -39294,10 +40298,10 @@ EdwardsCurve.prototype.pointFromY = function pointFromY(y, odd) {
   if (!y.red)
     y = y.toRed(this.red);
 
-  // x^2 = (y^2 - 1) / (d y^2 + 1)
+  // x^2 = (y^2 - c^2) / (c^2 d y^2 - a)
   var y2 = y.redSqr();
-  var lhs = y2.redSub(this.one);
-  var rhs = y2.redMul(this.d).redAdd(this.one);
+  var lhs = y2.redSub(this.c2);
+  var rhs = y2.redMul(this.d).redMul(this.c2).redSub(this.a);
   var x2 = lhs.redMul(rhs.redInvm());
 
   if (x2.cmp(this.zero) === 0) {
@@ -39311,7 +40315,7 @@ EdwardsCurve.prototype.pointFromY = function pointFromY(y, odd) {
   if (x.redSqr().redSub(x2).cmp(this.zero) !== 0)
     throw new Error('invalid point');
 
-  if (x.isOdd() !== odd)
+  if (x.fromRed().isOdd() !== odd)
     x = x.redNeg();
 
   return this.point(x, y);
@@ -39388,7 +40392,8 @@ Point.prototype.inspect = function inspect() {
 Point.prototype.isInfinity = function isInfinity() {
   // XXX This code assumes that zero is always zero in red
   return this.x.cmpn(0) === 0 &&
-         this.y.cmp(this.z) === 0;
+    (this.y.cmp(this.z) === 0 ||
+    (this.zOne && this.y.cmp(this.curve.c) === 0));
 };
 
 Point.prototype._extDbl = function _extDbl() {
@@ -39469,7 +40474,7 @@ Point.prototype._projDbl = function _projDbl() {
     // E = C + D
     var e = c.redAdd(d);
     // H = (c * Z1)^2
-    var h = this.curve._mulC(this.c.redMul(this.z)).redSqr();
+    var h = this.curve._mulC(this.z).redSqr();
     // J = E - 2 * H
     var j = e.redSub(h).redSub(h);
     // X3 = c * (B - E) * J
@@ -39645,14 +40650,13 @@ Point.prototype.eqXToP = function eqXToP(x) {
     if (this.x.cmp(rx) === 0)
       return true;
   }
-  return false;
 };
 
 // Compatibility with BaseCurve
 Point.prototype.toP = Point.prototype.normalize;
 Point.prototype.mixedAdd = Point.prototype.add;
 
-},{"../../elliptic":246,"../curve":249,"bn.js":196,"inherits":279}],249:[function(require,module,exports){
+},{"../../elliptic":252,"../curve":255,"bn.js":202,"inherits":285}],255:[function(require,module,exports){
 'use strict';
 
 var curve = exports;
@@ -39662,7 +40666,7 @@ curve.short = require('./short');
 curve.mont = require('./mont');
 curve.edwards = require('./edwards');
 
-},{"./base":247,"./edwards":248,"./mont":250,"./short":251}],250:[function(require,module,exports){
+},{"./base":253,"./edwards":254,"./mont":256,"./short":257}],256:[function(require,module,exports){
 'use strict';
 
 var curve = require('../curve');
@@ -39844,7 +40848,7 @@ Point.prototype.getX = function getX() {
   return this.x.fromRed();
 };
 
-},{"../../elliptic":246,"../curve":249,"bn.js":196,"inherits":279}],251:[function(require,module,exports){
+},{"../../elliptic":252,"../curve":255,"bn.js":202,"inherits":285}],257:[function(require,module,exports){
 'use strict';
 
 var curve = require('../curve');
@@ -40768,7 +41772,6 @@ JPoint.prototype.eqXToP = function eqXToP(x) {
     if (this.x.cmp(rx) === 0)
       return true;
   }
-  return false;
 };
 
 JPoint.prototype.inspect = function inspect() {
@@ -40784,7 +41787,7 @@ JPoint.prototype.isInfinity = function isInfinity() {
   return this.z.cmpn(0) === 0;
 };
 
-},{"../../elliptic":246,"../curve":249,"bn.js":196,"inherits":279}],252:[function(require,module,exports){
+},{"../../elliptic":252,"../curve":255,"bn.js":202,"inherits":285}],258:[function(require,module,exports){
 'use strict';
 
 var curves = exports;
@@ -40991,7 +41994,7 @@ defineCurve('secp256k1', {
   ]
 });
 
-},{"../elliptic":246,"./precomputed/secp256k1":259,"hash.js":265}],253:[function(require,module,exports){
+},{"../elliptic":252,"./precomputed/secp256k1":265,"hash.js":271}],259:[function(require,module,exports){
 'use strict';
 
 var BN = require('bn.js');
@@ -41233,7 +42236,7 @@ EC.prototype.getKeyRecoveryParam = function(e, signature, Q, enc) {
   throw new Error('Unable to find valid recovery factor');
 };
 
-},{"../../elliptic":246,"./key":254,"./signature":255,"bn.js":196,"hmac-drbg":277}],254:[function(require,module,exports){
+},{"../../elliptic":252,"./key":260,"./signature":261,"bn.js":202,"hmac-drbg":283}],260:[function(require,module,exports){
 'use strict';
 
 var BN = require('bn.js');
@@ -41354,7 +42357,7 @@ KeyPair.prototype.inspect = function inspect() {
          ' pub: ' + (this.pub && this.pub.inspect()) + ' >';
 };
 
-},{"../../elliptic":246,"bn.js":196}],255:[function(require,module,exports){
+},{"../../elliptic":252,"bn.js":202}],261:[function(require,module,exports){
 'use strict';
 
 var BN = require('bn.js');
@@ -41491,7 +42494,7 @@ Signature.prototype.toDER = function toDER(enc) {
   return utils.encode(res, enc);
 };
 
-},{"../../elliptic":246,"bn.js":196}],256:[function(require,module,exports){
+},{"../../elliptic":252,"bn.js":202}],262:[function(require,module,exports){
 'use strict';
 
 var hash = require('hash.js');
@@ -41611,7 +42614,7 @@ EDDSA.prototype.isPoint = function isPoint(val) {
   return val instanceof this.pointClass;
 };
 
-},{"../../elliptic":246,"./key":257,"./signature":258,"hash.js":265}],257:[function(require,module,exports){
+},{"../../elliptic":252,"./key":263,"./signature":264,"hash.js":271}],263:[function(require,module,exports){
 'use strict';
 
 var elliptic = require('../../elliptic');
@@ -41709,7 +42712,7 @@ KeyPair.prototype.getPublic = function getPublic(enc) {
 
 module.exports = KeyPair;
 
-},{"../../elliptic":246}],258:[function(require,module,exports){
+},{"../../elliptic":252}],264:[function(require,module,exports){
 'use strict';
 
 var BN = require('bn.js');
@@ -41777,7 +42780,7 @@ Signature.prototype.toHex = function toHex() {
 
 module.exports = Signature;
 
-},{"../../elliptic":246,"bn.js":196}],259:[function(require,module,exports){
+},{"../../elliptic":252,"bn.js":202}],265:[function(require,module,exports){
 module.exports = {
   doubles: {
     step: 4,
@@ -42559,7 +43562,7 @@ module.exports = {
   }
 };
 
-},{}],260:[function(require,module,exports){
+},{}],266:[function(require,module,exports){
 'use strict';
 
 var utils = exports;
@@ -42681,12 +43684,12 @@ function intFromLE(bytes) {
 utils.intFromLE = intFromLE;
 
 
-},{"bn.js":196,"minimalistic-assert":284,"minimalistic-crypto-utils":285}],261:[function(require,module,exports){
+},{"bn.js":202,"minimalistic-assert":290,"minimalistic-crypto-utils":291}],267:[function(require,module,exports){
 module.exports={
   "_from": "elliptic@^6.0.0",
-  "_id": "elliptic@6.4.0",
+  "_id": "elliptic@6.4.1",
   "_inBundle": false,
-  "_integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
+  "_integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
   "_location": "/browserify/elliptic",
   "_phantomChildren": {},
   "_requested": {
@@ -42703,10 +43706,10 @@ module.exports={
     "/browserify/browserify-sign",
     "/browserify/create-ecdh"
   ],
-  "_resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
-  "_shasum": "cac9af8762c85836187003c8dfe193e5e2eae5df",
+  "_resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
+  "_shasum": "c2d0b7776911b86722c632c3c06c60f2f819939a",
   "_spec": "elliptic@^6.0.0",
-  "_where": "/usr/lib/node_modules/browserify/node_modules/browserify-sign",
+  "_where": "/usr/local/lib/node_modules/browserify/node_modules/browserify-sign",
   "author": {
     "name": "Fedor Indutny",
     "email": "fedor@indutny.com"
@@ -42767,10 +43770,10 @@ module.exports={
     "unit": "istanbul test _mocha --reporter=spec test/index.js",
     "version": "grunt dist && git add dist/"
   },
-  "version": "6.4.0"
+  "version": "6.4.1"
 }
 
-},{}],262:[function(require,module,exports){
+},{}],268:[function(require,module,exports){
 // Copyright Joyent, Inc. and other Node contributors.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
@@ -43201,24 +44204,28 @@ EventEmitter.prototype.removeAllListeners =
       return this;
     };
 
-EventEmitter.prototype.listeners = function listeners(type) {
-  var evlistener;
-  var ret;
-  var events = this._events;
+function _listeners(target, type, unwrap) {
+  var events = target._events;
 
   if (!events)
-    ret = [];
-  else {
-    evlistener = events[type];
-    if (!evlistener)
-      ret = [];
-    else if (typeof evlistener === 'function')
-      ret = [evlistener.listener || evlistener];
-    else
-      ret = unwrapListeners(evlistener);
-  }
+    return [];
 
-  return ret;
+  var evlistener = events[type];
+  if (!evlistener)
+    return [];
+
+  if (typeof evlistener === 'function')
+    return unwrap ? [evlistener.listener || evlistener] : [evlistener];
+
+  return unwrap ? unwrapListeners(evlistener) : arrayClone(evlistener, evlistener.length);
+}
+
+EventEmitter.prototype.listeners = function listeners(type) {
+  return _listeners(this, type, true);
+};
+
+EventEmitter.prototype.rawListeners = function rawListeners(type) {
+  return _listeners(this, type, false);
 };
 
 EventEmitter.listenerCount = function(emitter, type) {
@@ -43291,11 +44298,11 @@ function functionBindPolyfill(context) {
   };
 }
 
-},{}],263:[function(require,module,exports){
+},{}],269:[function(require,module,exports){
 arguments[4][44][0].apply(exports,arguments)
-},{"dup":44,"md5.js":282,"safe-buffer":320}],264:[function(require,module,exports){
+},{"dup":44,"md5.js":288,"safe-buffer":326}],270:[function(require,module,exports){
 arguments[4][45][0].apply(exports,arguments)
-},{"dup":45,"inherits":279,"safe-buffer":320,"stream":329}],265:[function(require,module,exports){
+},{"dup":45,"inherits":285,"safe-buffer":326,"stream":335}],271:[function(require,module,exports){
 var hash = exports;
 
 hash.utils = require('./hash/utils');
@@ -43312,7 +44319,7 @@ hash.sha384 = hash.sha.sha384;
 hash.sha512 = hash.sha.sha512;
 hash.ripemd160 = hash.ripemd.ripemd160;
 
-},{"./hash/common":266,"./hash/hmac":267,"./hash/ripemd":268,"./hash/sha":269,"./hash/utils":276}],266:[function(require,module,exports){
+},{"./hash/common":272,"./hash/hmac":273,"./hash/ripemd":274,"./hash/sha":275,"./hash/utils":282}],272:[function(require,module,exports){
 'use strict';
 
 var utils = require('./utils');
@@ -43406,7 +44413,7 @@ BlockHash.prototype._pad = function pad() {
   return res;
 };
 
-},{"./utils":276,"minimalistic-assert":284}],267:[function(require,module,exports){
+},{"./utils":282,"minimalistic-assert":290}],273:[function(require,module,exports){
 'use strict';
 
 var utils = require('./utils');
@@ -43455,7 +44462,7 @@ Hmac.prototype.digest = function digest(enc) {
   return this.outer.digest(enc);
 };
 
-},{"./utils":276,"minimalistic-assert":284}],268:[function(require,module,exports){
+},{"./utils":282,"minimalistic-assert":290}],274:[function(require,module,exports){
 'use strict';
 
 var utils = require('./utils');
@@ -43603,7 +44610,7 @@ var sh = [
   8, 5, 12, 9, 12, 5, 14, 6, 8, 13, 6, 5, 15, 13, 11, 11
 ];
 
-},{"./common":266,"./utils":276}],269:[function(require,module,exports){
+},{"./common":272,"./utils":282}],275:[function(require,module,exports){
 'use strict';
 
 exports.sha1 = require('./sha/1');
@@ -43612,7 +44619,7 @@ exports.sha256 = require('./sha/256');
 exports.sha384 = require('./sha/384');
 exports.sha512 = require('./sha/512');
 
-},{"./sha/1":270,"./sha/224":271,"./sha/256":272,"./sha/384":273,"./sha/512":274}],270:[function(require,module,exports){
+},{"./sha/1":276,"./sha/224":277,"./sha/256":278,"./sha/384":279,"./sha/512":280}],276:[function(require,module,exports){
 'use strict';
 
 var utils = require('../utils');
@@ -43688,7 +44695,7 @@ SHA1.prototype._digest = function digest(enc) {
     return utils.split32(this.h, 'big');
 };
 
-},{"../common":266,"../utils":276,"./common":275}],271:[function(require,module,exports){
+},{"../common":272,"../utils":282,"./common":281}],277:[function(require,module,exports){
 'use strict';
 
 var utils = require('../utils');
@@ -43720,7 +44727,7 @@ SHA224.prototype._digest = function digest(enc) {
 };
 
 
-},{"../utils":276,"./256":272}],272:[function(require,module,exports){
+},{"../utils":282,"./256":278}],278:[function(require,module,exports){
 'use strict';
 
 var utils = require('../utils');
@@ -43827,7 +44834,7 @@ SHA256.prototype._digest = function digest(enc) {
     return utils.split32(this.h, 'big');
 };
 
-},{"../common":266,"../utils":276,"./common":275,"minimalistic-assert":284}],273:[function(require,module,exports){
+},{"../common":272,"../utils":282,"./common":281,"minimalistic-assert":290}],279:[function(require,module,exports){
 'use strict';
 
 var utils = require('../utils');
@@ -43864,7 +44871,7 @@ SHA384.prototype._digest = function digest(enc) {
     return utils.split32(this.h.slice(0, 12), 'big');
 };
 
-},{"../utils":276,"./512":274}],274:[function(require,module,exports){
+},{"../utils":282,"./512":280}],280:[function(require,module,exports){
 'use strict';
 
 var utils = require('../utils');
@@ -44196,7 +45203,7 @@ function g1_512_lo(xh, xl) {
   return r;
 }
 
-},{"../common":266,"../utils":276,"minimalistic-assert":284}],275:[function(require,module,exports){
+},{"../common":272,"../utils":282,"minimalistic-assert":290}],281:[function(require,module,exports){
 'use strict';
 
 var utils = require('../utils');
@@ -44247,7 +45254,7 @@ function g1_256(x) {
 }
 exports.g1_256 = g1_256;
 
-},{"../utils":276}],276:[function(require,module,exports){
+},{"../utils":282}],282:[function(require,module,exports){
 'use strict';
 
 var assert = require('minimalistic-assert');
@@ -44502,7 +45509,7 @@ function shr64_lo(ah, al, num) {
 }
 exports.shr64_lo = shr64_lo;
 
-},{"inherits":279,"minimalistic-assert":284}],277:[function(require,module,exports){
+},{"inherits":285,"minimalistic-assert":290}],283:[function(require,module,exports){
 'use strict';
 
 var hash = require('hash.js');
@@ -44617,7 +45624,7 @@ HmacDRBG.prototype.generate = function generate(len, enc, add, addEnc) {
   return utils.encode(res, enc);
 };
 
-},{"hash.js":265,"minimalistic-assert":284,"minimalistic-crypto-utils":285}],278:[function(require,module,exports){
+},{"hash.js":271,"minimalistic-assert":290,"minimalistic-crypto-utils":291}],284:[function(require,module,exports){
 exports.read = function (buffer, offset, isLE, mLen, nBytes) {
   var e, m
   var eLen = (nBytes * 8) - mLen - 1
@@ -44703,9 +45710,9 @@ exports.write = function (buffer, value, offset, isLE, mLen, nBytes) {
   buffer[offset + i - d] |= s * 128
 }
 
-},{}],279:[function(require,module,exports){
+},{}],285:[function(require,module,exports){
 arguments[4][46][0].apply(exports,arguments)
-},{"dup":46}],280:[function(require,module,exports){
+},{"dup":46}],286:[function(require,module,exports){
 /*!
  * Determine if an object is a Buffer
  *
@@ -44728,163 +45735,16 @@ function isSlowBuffer (obj) {
   return typeof obj.readFloatLE === 'function' && typeof obj.slice === 'function' && isBuffer(obj.slice(0, 0))
 }
 
-},{}],281:[function(require,module,exports){
+},{}],287:[function(require,module,exports){
 var toString = {}.toString;
 
 module.exports = Array.isArray || function (arr) {
   return toString.call(arr) == '[object Array]';
 };
 
-},{}],282:[function(require,module,exports){
-(function (Buffer){
-'use strict'
-var inherits = require('inherits')
-var HashBase = require('hash-base')
-
-var ARRAY16 = new Array(16)
-
-function MD5 () {
-  HashBase.call(this, 64)
-
-  // state
-  this._a = 0x67452301
-  this._b = 0xefcdab89
-  this._c = 0x98badcfe
-  this._d = 0x10325476
-}
-
-inherits(MD5, HashBase)
-
-MD5.prototype._update = function () {
-  var M = ARRAY16
-  for (var i = 0; i < 16; ++i) M[i] = this._block.readInt32LE(i * 4)
-
-  var a = this._a
-  var b = this._b
-  var c = this._c
-  var d = this._d
-
-  a = fnF(a, b, c, d, M[0], 0xd76aa478, 7)
-  d = fnF(d, a, b, c, M[1], 0xe8c7b756, 12)
-  c = fnF(c, d, a, b, M[2], 0x242070db, 17)
-  b = fnF(b, c, d, a, M[3], 0xc1bdceee, 22)
-  a = fnF(a, b, c, d, M[4], 0xf57c0faf, 7)
-  d = fnF(d, a, b, c, M[5], 0x4787c62a, 12)
-  c = fnF(c, d, a, b, M[6], 0xa8304613, 17)
-  b = fnF(b, c, d, a, M[7], 0xfd469501, 22)
-  a = fnF(a, b, c, d, M[8], 0x698098d8, 7)
-  d = fnF(d, a, b, c, M[9], 0x8b44f7af, 12)
-  c = fnF(c, d, a, b, M[10], 0xffff5bb1, 17)
-  b = fnF(b, c, d, a, M[11], 0x895cd7be, 22)
-  a = fnF(a, b, c, d, M[12], 0x6b901122, 7)
-  d = fnF(d, a, b, c, M[13], 0xfd987193, 12)
-  c = fnF(c, d, a, b, M[14], 0xa679438e, 17)
-  b = fnF(b, c, d, a, M[15], 0x49b40821, 22)
-
-  a = fnG(a, b, c, d, M[1], 0xf61e2562, 5)
-  d = fnG(d, a, b, c, M[6], 0xc040b340, 9)
-  c = fnG(c, d, a, b, M[11], 0x265e5a51, 14)
-  b = fnG(b, c, d, a, M[0], 0xe9b6c7aa, 20)
-  a = fnG(a, b, c, d, M[5], 0xd62f105d, 5)
-  d = fnG(d, a, b, c, M[10], 0x02441453, 9)
-  c = fnG(c, d, a, b, M[15], 0xd8a1e681, 14)
-  b = fnG(b, c, d, a, M[4], 0xe7d3fbc8, 20)
-  a = fnG(a, b, c, d, M[9], 0x21e1cde6, 5)
-  d = fnG(d, a, b, c, M[14], 0xc33707d6, 9)
-  c = fnG(c, d, a, b, M[3], 0xf4d50d87, 14)
-  b = fnG(b, c, d, a, M[8], 0x455a14ed, 20)
-  a = fnG(a, b, c, d, M[13], 0xa9e3e905, 5)
-  d = fnG(d, a, b, c, M[2], 0xfcefa3f8, 9)
-  c = fnG(c, d, a, b, M[7], 0x676f02d9, 14)
-  b = fnG(b, c, d, a, M[12], 0x8d2a4c8a, 20)
-
-  a = fnH(a, b, c, d, M[5], 0xfffa3942, 4)
-  d = fnH(d, a, b, c, M[8], 0x8771f681, 11)
-  c = fnH(c, d, a, b, M[11], 0x6d9d6122, 16)
-  b = fnH(b, c, d, a, M[14], 0xfde5380c, 23)
-  a = fnH(a, b, c, d, M[1], 0xa4beea44, 4)
-  d = fnH(d, a, b, c, M[4], 0x4bdecfa9, 11)
-  c = fnH(c, d, a, b, M[7], 0xf6bb4b60, 16)
-  b = fnH(b, c, d, a, M[10], 0xbebfbc70, 23)
-  a = fnH(a, b, c, d, M[13], 0x289b7ec6, 4)
-  d = fnH(d, a, b, c, M[0], 0xeaa127fa, 11)
-  c = fnH(c, d, a, b, M[3], 0xd4ef3085, 16)
-  b = fnH(b, c, d, a, M[6], 0x04881d05, 23)
-  a = fnH(a, b, c, d, M[9], 0xd9d4d039, 4)
-  d = fnH(d, a, b, c, M[12], 0xe6db99e5, 11)
-  c = fnH(c, d, a, b, M[15], 0x1fa27cf8, 16)
-  b = fnH(b, c, d, a, M[2], 0xc4ac5665, 23)
-
-  a = fnI(a, b, c, d, M[0], 0xf4292244, 6)
-  d = fnI(d, a, b, c, M[7], 0x432aff97, 10)
-  c = fnI(c, d, a, b, M[14], 0xab9423a7, 15)
-  b = fnI(b, c, d, a, M[5], 0xfc93a039, 21)
-  a = fnI(a, b, c, d, M[12], 0x655b59c3, 6)
-  d = fnI(d, a, b, c, M[3], 0x8f0ccc92, 10)
-  c = fnI(c, d, a, b, M[10], 0xffeff47d, 15)
-  b = fnI(b, c, d, a, M[1], 0x85845dd1, 21)
-  a = fnI(a, b, c, d, M[8], 0x6fa87e4f, 6)
-  d = fnI(d, a, b, c, M[15], 0xfe2ce6e0, 10)
-  c = fnI(c, d, a, b, M[6], 0xa3014314, 15)
-  b = fnI(b, c, d, a, M[13], 0x4e0811a1, 21)
-  a = fnI(a, b, c, d, M[4], 0xf7537e82, 6)
-  d = fnI(d, a, b, c, M[11], 0xbd3af235, 10)
-  c = fnI(c, d, a, b, M[2], 0x2ad7d2bb, 15)
-  b = fnI(b, c, d, a, M[9], 0xeb86d391, 21)
-
-  this._a = (this._a + a) | 0
-  this._b = (this._b + b) | 0
-  this._c = (this._c + c) | 0
-  this._d = (this._d + d) | 0
-}
-
-MD5.prototype._digest = function () {
-  // create padding and handle blocks
-  this._block[this._blockOffset++] = 0x80
-  if (this._blockOffset > 56) {
-    this._block.fill(0, this._blockOffset, 64)
-    this._update()
-    this._blockOffset = 0
-  }
-
-  this._block.fill(0, this._blockOffset, 56)
-  this._block.writeUInt32LE(this._length[0], 56)
-  this._block.writeUInt32LE(this._length[1], 60)
-  this._update()
-
-  // produce result
-  var buffer = new Buffer(16)
-  buffer.writeInt32LE(this._a, 0)
-  buffer.writeInt32LE(this._b, 4)
-  buffer.writeInt32LE(this._c, 8)
-  buffer.writeInt32LE(this._d, 12)
-  return buffer
-}
-
-function rotl (x, n) {
-  return (x << n) | (x >>> (32 - n))
-}
-
-function fnF (a, b, c, d, m, k, s) {
-  return (rotl((a + ((b & c) | ((~b) & d)) + m + k) | 0, s) + b) | 0
-}
-
-function fnG (a, b, c, d, m, k, s) {
-  return (rotl((a + ((b & d) | (c & (~d))) + m + k) | 0, s) + b) | 0
-}
-
-function fnH (a, b, c, d, m, k, s) {
-  return (rotl((a + (b ^ c ^ d) + m + k) | 0, s) + b) | 0
-}
-
-function fnI (a, b, c, d, m, k, s) {
-  return (rotl((a + ((c ^ (b | (~d)))) + m + k) | 0, s) + b) | 0
-}
-
-module.exports = MD5
-
-}).call(this,require("buffer").Buffer)
-},{"buffer":227,"hash-base":264,"inherits":279}],283:[function(require,module,exports){
+},{}],288:[function(require,module,exports){
+arguments[4][128][0].apply(exports,arguments)
+},{"dup":128,"hash-base":270,"inherits":285,"safe-buffer":326}],289:[function(require,module,exports){
 var bn = require('bn.js');
 var brorand = require('brorand');
 
@@ -45001,7 +45861,7 @@ MillerRabin.prototype.getDivisor = function getDivisor(n, k) {
   return false;
 };
 
-},{"bn.js":196,"brorand":197}],284:[function(require,module,exports){
+},{"bn.js":202,"brorand":203}],290:[function(require,module,exports){
 module.exports = assert;
 
 function assert(val, msg) {
@@ -45014,7 +45874,7 @@ assert.equal = function assertEqual(l, r, msg) {
     throw new Error(msg || ('Assertion failed: ' + l + ' != ' + r));
 };
 
-},{}],285:[function(require,module,exports){
+},{}],291:[function(require,module,exports){
 'use strict';
 
 var utils = exports;
@@ -45074,7 +45934,7 @@ utils.encode = function encode(arr, enc) {
     return arr;
 };
 
-},{}],286:[function(require,module,exports){
+},{}],292:[function(require,module,exports){
 module.exports={"2.16.840.1.101.3.4.1.1": "aes-128-ecb",
 "2.16.840.1.101.3.4.1.2": "aes-128-cbc",
 "2.16.840.1.101.3.4.1.3": "aes-128-ofb",
@@ -45088,7 +45948,7 @@ module.exports={"2.16.840.1.101.3.4.1.1": "aes-128-ecb",
 "2.16.840.1.101.3.4.1.43": "aes-256-ofb",
 "2.16.840.1.101.3.4.1.44": "aes-256-cfb"
 }
-},{}],287:[function(require,module,exports){
+},{}],293:[function(require,module,exports){
 // from https://github.com/indutny/self-signed/blob/gh-pages/lib/asn1.js
 // Fedor, you are amazing.
 'use strict'
@@ -45212,7 +46072,7 @@ exports.signature = asn1.define('signature', function () {
   )
 })
 
-},{"./certificate":288,"asn1.js":180}],288:[function(require,module,exports){
+},{"./certificate":294,"asn1.js":183}],294:[function(require,module,exports){
 // from https://github.com/Rantanen/node-dtls/blob/25a7dc861bda38cfeac93a723500eea4f0ac2e86/Certificate.js
 // thanks to @Rantanen
 
@@ -45302,7 +46162,7 @@ var X509Certificate = asn.define('X509Certificate', function () {
 
 module.exports = X509Certificate
 
-},{"asn1.js":180}],289:[function(require,module,exports){
+},{"asn1.js":183}],295:[function(require,module,exports){
 (function (Buffer){
 // adapted from https://github.com/apatil/pemstrip
 var findProc = /Proc-Type: 4,ENCRYPTED[\n\r]+DEK-Info: AES-((?:128)|(?:192)|(?:256))-CBC,([0-9A-H]+)[\n\r]+([0-9A-z\n\r\+\/\=]+)[\n\r]+/m
@@ -45336,7 +46196,7 @@ module.exports = function (okey, password) {
 }
 
 }).call(this,require("buffer").Buffer)
-},{"browserify-aes":201,"buffer":227,"evp_bytestokey":263}],290:[function(require,module,exports){
+},{"browserify-aes":207,"buffer":233,"evp_bytestokey":269}],296:[function(require,module,exports){
 (function (Buffer){
 var asn1 = require('./asn1')
 var aesid = require('./aesid.json')
@@ -45446,11 +46306,11 @@ function decrypt (data, password) {
 }
 
 }).call(this,require("buffer").Buffer)
-},{"./aesid.json":286,"./asn1":287,"./fixProc":289,"browserify-aes":201,"buffer":227,"pbkdf2":291}],291:[function(require,module,exports){
+},{"./aesid.json":292,"./asn1":293,"./fixProc":295,"browserify-aes":207,"buffer":233,"pbkdf2":297}],297:[function(require,module,exports){
 exports.pbkdf2 = require('./lib/async')
 exports.pbkdf2Sync = require('./lib/sync')
 
-},{"./lib/async":292,"./lib/sync":295}],292:[function(require,module,exports){
+},{"./lib/async":298,"./lib/sync":301}],298:[function(require,module,exports){
 (function (process,global){
 var checkParameters = require('./precondition')
 var defaultEncoding = require('./default-encoding')
@@ -45554,7 +46414,7 @@ module.exports = function (password, salt, iterations, keylen, digest, callback)
 }
 
 }).call(this,require('_process'),typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./default-encoding":293,"./precondition":294,"./sync":295,"_process":297,"safe-buffer":320}],293:[function(require,module,exports){
+},{"./default-encoding":299,"./precondition":300,"./sync":301,"_process":303,"safe-buffer":326}],299:[function(require,module,exports){
 (function (process){
 var defaultEncoding
 /* istanbul ignore next */
@@ -45568,7 +46428,7 @@ if (process.browser) {
 module.exports = defaultEncoding
 
 }).call(this,require('_process'))
-},{"_process":297}],294:[function(require,module,exports){
+},{"_process":303}],300:[function(require,module,exports){
 (function (Buffer){
 var MAX_ALLOC = Math.pow(2, 30) - 1 // default in iojs
 
@@ -45600,9 +46460,9 @@ module.exports = function (password, salt, iterations, keylen) {
 }
 
 }).call(this,{"isBuffer":require("../../is-buffer/index.js")})
-},{"../../is-buffer/index.js":280}],295:[function(require,module,exports){
+},{"../../is-buffer/index.js":286}],301:[function(require,module,exports){
 var md5 = require('create-hash/md5')
-var rmd160 = require('ripemd160')
+var RIPEMD160 = require('ripemd160')
 var sha = require('sha.js')
 
 var checkParameters = require('./precondition')
@@ -45659,8 +46519,11 @@ function getDigest (alg) {
   function shaFunc (data) {
     return sha(alg).update(data).digest()
   }
+  function rmd160Func (data) {
+    return new RIPEMD160().update(data).digest()
+  }
 
-  if (alg === 'rmd160' || alg === 'ripemd160') return rmd160
+  if (alg === 'rmd160' || alg === 'ripemd160') return rmd160Func
   if (alg === 'md5') return md5
   return shaFunc
 }
@@ -45703,7 +46566,7 @@ function pbkdf2 (password, salt, iterations, keylen, digest) {
 
 module.exports = pbkdf2
 
-},{"./default-encoding":293,"./precondition":294,"create-hash/md5":232,"ripemd160":319,"safe-buffer":320,"sha.js":322}],296:[function(require,module,exports){
+},{"./default-encoding":299,"./precondition":300,"create-hash/md5":238,"ripemd160":325,"safe-buffer":326,"sha.js":328}],302:[function(require,module,exports){
 (function (process){
 'use strict';
 
@@ -45751,7 +46614,7 @@ function nextTick(fn, arg1, arg2, arg3) {
 
 
 }).call(this,require('_process'))
-},{"_process":297}],297:[function(require,module,exports){
+},{"_process":303}],303:[function(require,module,exports){
 // shim for using process in browser
 var process = module.exports = {};
 
@@ -45937,268 +46800,261 @@ process.chdir = function (dir) {
 };
 process.umask = function() { return 0; };
 
-},{}],298:[function(require,module,exports){
-exports.publicEncrypt = require('./publicEncrypt');
-exports.privateDecrypt = require('./privateDecrypt');
+},{}],304:[function(require,module,exports){
+exports.publicEncrypt = require('./publicEncrypt')
+exports.privateDecrypt = require('./privateDecrypt')
 
-exports.privateEncrypt = function privateEncrypt(key, buf) {
-  return exports.publicEncrypt(key, buf, true);
-};
-
-exports.publicDecrypt = function publicDecrypt(key, buf) {
-  return exports.privateDecrypt(key, buf, true);
-};
-},{"./privateDecrypt":300,"./publicEncrypt":301}],299:[function(require,module,exports){
-(function (Buffer){
-var createHash = require('create-hash');
-module.exports = function (seed, len) {
-  var t = new Buffer('');
-  var  i = 0, c;
-  while (t.length < len) {
-    c = i2ops(i++);
-    t = Buffer.concat([t, createHash('sha1').update(seed).update(c).digest()]);
-  }
-  return t.slice(0, len);
-};
-
-function i2ops(c) {
-  var out = new Buffer(4);
-  out.writeUInt32BE(c,0);
-  return out;
+exports.privateEncrypt = function privateEncrypt (key, buf) {
+  return exports.publicEncrypt(key, buf, true)
 }
-}).call(this,require("buffer").Buffer)
-},{"buffer":227,"create-hash":231}],300:[function(require,module,exports){
-(function (Buffer){
-var parseKeys = require('parse-asn1');
-var mgf = require('./mgf');
-var xor = require('./xor');
-var bn = require('bn.js');
-var crt = require('browserify-rsa');
-var createHash = require('create-hash');
-var withPublic = require('./withPublic');
-module.exports = function privateDecrypt(private_key, enc, reverse) {
-  var padding;
-  if (private_key.padding) {
-    padding = private_key.padding;
+
+exports.publicDecrypt = function publicDecrypt (key, buf) {
+  return exports.privateDecrypt(key, buf, true)
+}
+
+},{"./privateDecrypt":306,"./publicEncrypt":307}],305:[function(require,module,exports){
+var createHash = require('create-hash')
+var Buffer = require('safe-buffer').Buffer
+
+module.exports = function (seed, len) {
+  var t = Buffer.alloc(0)
+  var i = 0
+  var c
+  while (t.length < len) {
+    c = i2ops(i++)
+    t = Buffer.concat([t, createHash('sha1').update(seed).update(c).digest()])
+  }
+  return t.slice(0, len)
+}
+
+function i2ops (c) {
+  var out = Buffer.allocUnsafe(4)
+  out.writeUInt32BE(c, 0)
+  return out
+}
+
+},{"create-hash":237,"safe-buffer":326}],306:[function(require,module,exports){
+var parseKeys = require('parse-asn1')
+var mgf = require('./mgf')
+var xor = require('./xor')
+var BN = require('bn.js')
+var crt = require('browserify-rsa')
+var createHash = require('create-hash')
+var withPublic = require('./withPublic')
+var Buffer = require('safe-buffer').Buffer
+
+module.exports = function privateDecrypt (privateKey, enc, reverse) {
+  var padding
+  if (privateKey.padding) {
+    padding = privateKey.padding
   } else if (reverse) {
-    padding = 1;
+    padding = 1
   } else {
-    padding = 4;
+    padding = 4
   }
 
-  var key = parseKeys(private_key);
-  var k = key.modulus.byteLength();
-  if (enc.length > k || new bn(enc).cmp(key.modulus) >= 0) {
-    throw new Error('decryption error');
+  var key = parseKeys(privateKey)
+  var k = key.modulus.byteLength()
+  if (enc.length > k || new BN(enc).cmp(key.modulus) >= 0) {
+    throw new Error('decryption error')
   }
-  var msg;
+  var msg
   if (reverse) {
-    msg = withPublic(new bn(enc), key);
+    msg = withPublic(new BN(enc), key)
   } else {
-    msg = crt(enc, key);
+    msg = crt(enc, key)
   }
-  var zBuffer = new Buffer(k - msg.length);
-  zBuffer.fill(0);
-  msg = Buffer.concat([zBuffer, msg], k);
+  var zBuffer = Buffer.alloc(k - msg.length)
+  msg = Buffer.concat([zBuffer, msg], k)
   if (padding === 4) {
-    return oaep(key, msg);
+    return oaep(key, msg)
   } else if (padding === 1) {
-    return pkcs1(key, msg, reverse);
+    return pkcs1(key, msg, reverse)
   } else if (padding === 3) {
-    return msg;
+    return msg
   } else {
-    throw new Error('unknown padding');
+    throw new Error('unknown padding')
   }
-};
+}
 
-function oaep(key, msg){
-  var n = key.modulus;
-  var k = key.modulus.byteLength();
-  var mLen = msg.length;
-  var iHash = createHash('sha1').update(new Buffer('')).digest();
-  var hLen = iHash.length;
-  var hLen2 = 2 * hLen;
+function oaep (key, msg) {
+  var k = key.modulus.byteLength()
+  var iHash = createHash('sha1').update(Buffer.alloc(0)).digest()
+  var hLen = iHash.length
   if (msg[0] !== 0) {
-    throw new Error('decryption error');
+    throw new Error('decryption error')
   }
-  var maskedSeed = msg.slice(1, hLen + 1);
-  var maskedDb =  msg.slice(hLen + 1);
-  var seed = xor(maskedSeed, mgf(maskedDb, hLen));
-  var db = xor(maskedDb, mgf(seed, k - hLen - 1));
+  var maskedSeed = msg.slice(1, hLen + 1)
+  var maskedDb = msg.slice(hLen + 1)
+  var seed = xor(maskedSeed, mgf(maskedDb, hLen))
+  var db = xor(maskedDb, mgf(seed, k - hLen - 1))
   if (compare(iHash, db.slice(0, hLen))) {
-    throw new Error('decryption error');
+    throw new Error('decryption error')
   }
-  var i = hLen;
+  var i = hLen
   while (db[i] === 0) {
-    i++;
+    i++
   }
   if (db[i++] !== 1) {
-    throw new Error('decryption error');
+    throw new Error('decryption error')
   }
-  return db.slice(i);
+  return db.slice(i)
 }
 
-function pkcs1(key, msg, reverse){
-  var p1 = msg.slice(0, 2);
-  var i = 2;
-  var status = 0;
+function pkcs1 (key, msg, reverse) {
+  var p1 = msg.slice(0, 2)
+  var i = 2
+  var status = 0
   while (msg[i++] !== 0) {
     if (i >= msg.length) {
-      status++;
-      break;
+      status++
+      break
     }
   }
-  var ps = msg.slice(2, i - 1);
-  var p2 = msg.slice(i - 1, i);
+  var ps = msg.slice(2, i - 1)
 
-  if ((p1.toString('hex') !== '0002' && !reverse) || (p1.toString('hex') !== '0001' && reverse)){
-    status++;
+  if ((p1.toString('hex') !== '0002' && !reverse) || (p1.toString('hex') !== '0001' && reverse)) {
+    status++
   }
   if (ps.length < 8) {
-    status++;
+    status++
   }
   if (status) {
-    throw new Error('decryption error');
+    throw new Error('decryption error')
   }
-  return  msg.slice(i);
+  return msg.slice(i)
 }
-function compare(a, b){
-  a = new Buffer(a);
-  b = new Buffer(b);
-  var dif = 0;
-  var len = a.length;
+function compare (a, b) {
+  a = Buffer.from(a)
+  b = Buffer.from(b)
+  var dif = 0
+  var len = a.length
   if (a.length !== b.length) {
-    dif++;
-    len = Math.min(a.length, b.length);
+    dif++
+    len = Math.min(a.length, b.length)
   }
-  var i = -1;
+  var i = -1
   while (++i < len) {
-    dif += (a[i] ^ b[i]);
+    dif += (a[i] ^ b[i])
   }
-  return dif;
+  return dif
 }
-}).call(this,require("buffer").Buffer)
-},{"./mgf":299,"./withPublic":302,"./xor":303,"bn.js":196,"browserify-rsa":219,"buffer":227,"create-hash":231,"parse-asn1":290}],301:[function(require,module,exports){
-(function (Buffer){
-var parseKeys = require('parse-asn1');
-var randomBytes = require('randombytes');
-var createHash = require('create-hash');
-var mgf = require('./mgf');
-var xor = require('./xor');
-var bn = require('bn.js');
-var withPublic = require('./withPublic');
-var crt = require('browserify-rsa');
 
-var constants = {
-  RSA_PKCS1_OAEP_PADDING: 4,
-  RSA_PKCS1_PADDIN: 1,
-  RSA_NO_PADDING: 3
-};
+},{"./mgf":305,"./withPublic":308,"./xor":309,"bn.js":202,"browserify-rsa":225,"create-hash":237,"parse-asn1":296,"safe-buffer":326}],307:[function(require,module,exports){
+var parseKeys = require('parse-asn1')
+var randomBytes = require('randombytes')
+var createHash = require('create-hash')
+var mgf = require('./mgf')
+var xor = require('./xor')
+var BN = require('bn.js')
+var withPublic = require('./withPublic')
+var crt = require('browserify-rsa')
+var Buffer = require('safe-buffer').Buffer
 
-module.exports = function publicEncrypt(public_key, msg, reverse) {
-  var padding;
-  if (public_key.padding) {
-    padding = public_key.padding;
+module.exports = function publicEncrypt (publicKey, msg, reverse) {
+  var padding
+  if (publicKey.padding) {
+    padding = publicKey.padding
   } else if (reverse) {
-    padding = 1;
+    padding = 1
   } else {
-    padding = 4;
+    padding = 4
   }
-  var key = parseKeys(public_key);
-  var paddedMsg;
+  var key = parseKeys(publicKey)
+  var paddedMsg
   if (padding === 4) {
-    paddedMsg = oaep(key, msg);
+    paddedMsg = oaep(key, msg)
   } else if (padding === 1) {
-    paddedMsg = pkcs1(key, msg, reverse);
+    paddedMsg = pkcs1(key, msg, reverse)
   } else if (padding === 3) {
-    paddedMsg = new bn(msg);
+    paddedMsg = new BN(msg)
     if (paddedMsg.cmp(key.modulus) >= 0) {
-      throw new Error('data too long for modulus');
+      throw new Error('data too long for modulus')
     }
   } else {
-    throw new Error('unknown padding');
+    throw new Error('unknown padding')
   }
   if (reverse) {
-    return crt(paddedMsg, key);
+    return crt(paddedMsg, key)
   } else {
-    return withPublic(paddedMsg, key);
+    return withPublic(paddedMsg, key)
   }
-};
+}
 
-function oaep(key, msg){
-  var k = key.modulus.byteLength();
-  var mLen = msg.length;
-  var iHash = createHash('sha1').update(new Buffer('')).digest();
-  var hLen = iHash.length;
-  var hLen2 = 2 * hLen;
+function oaep (key, msg) {
+  var k = key.modulus.byteLength()
+  var mLen = msg.length
+  var iHash = createHash('sha1').update(Buffer.alloc(0)).digest()
+  var hLen = iHash.length
+  var hLen2 = 2 * hLen
   if (mLen > k - hLen2 - 2) {
-    throw new Error('message too long');
+    throw new Error('message too long')
   }
-  var ps = new Buffer(k - mLen - hLen2 - 2);
-  ps.fill(0);
-  var dblen = k - hLen - 1;
-  var seed = randomBytes(hLen);
-  var maskedDb = xor(Buffer.concat([iHash, ps, new Buffer([1]), msg], dblen), mgf(seed, dblen));
-  var maskedSeed = xor(seed, mgf(maskedDb, hLen));
-  return new bn(Buffer.concat([new Buffer([0]), maskedSeed, maskedDb], k));
+  var ps = Buffer.alloc(k - mLen - hLen2 - 2)
+  var dblen = k - hLen - 1
+  var seed = randomBytes(hLen)
+  var maskedDb = xor(Buffer.concat([iHash, ps, Buffer.alloc(1, 1), msg], dblen), mgf(seed, dblen))
+  var maskedSeed = xor(seed, mgf(maskedDb, hLen))
+  return new BN(Buffer.concat([Buffer.alloc(1), maskedSeed, maskedDb], k))
 }
-function pkcs1(key, msg, reverse){
-  var mLen = msg.length;
-  var k = key.modulus.byteLength();
+function pkcs1 (key, msg, reverse) {
+  var mLen = msg.length
+  var k = key.modulus.byteLength()
   if (mLen > k - 11) {
-    throw new Error('message too long');
+    throw new Error('message too long')
   }
-  var ps;
+  var ps
   if (reverse) {
-    ps = new Buffer(k - mLen - 3);
-    ps.fill(0xff);
+    ps = Buffer.alloc(k - mLen - 3, 0xff)
   } else {
-    ps = nonZero(k - mLen - 3);
+    ps = nonZero(k - mLen - 3)
   }
-  return new bn(Buffer.concat([new Buffer([0, reverse?1:2]), ps, new Buffer([0]), msg], k));
+  return new BN(Buffer.concat([Buffer.from([0, reverse ? 1 : 2]), ps, Buffer.alloc(1), msg], k))
 }
-function nonZero(len, crypto) {
-  var out = new Buffer(len);
-  var i = 0;
-  var cache = randomBytes(len*2);
-  var cur = 0;
-  var num;
+function nonZero (len) {
+  var out = Buffer.allocUnsafe(len)
+  var i = 0
+  var cache = randomBytes(len * 2)
+  var cur = 0
+  var num
   while (i < len) {
     if (cur === cache.length) {
-      cache = randomBytes(len*2);
-      cur = 0;
+      cache = randomBytes(len * 2)
+      cur = 0
     }
-    num = cache[cur++];
+    num = cache[cur++]
     if (num) {
-      out[i++] = num;
+      out[i++] = num
     }
   }
-  return out;
-}
-}).call(this,require("buffer").Buffer)
-},{"./mgf":299,"./withPublic":302,"./xor":303,"bn.js":196,"browserify-rsa":219,"buffer":227,"create-hash":231,"parse-asn1":290,"randombytes":304}],302:[function(require,module,exports){
-(function (Buffer){
-var bn = require('bn.js');
-function withPublic(paddedMsg, key) {
-  return new Buffer(paddedMsg
-    .toRed(bn.mont(key.modulus))
-    .redPow(new bn(key.publicExponent))
-    .fromRed()
-    .toArray());
+  return out
 }
 
-module.exports = withPublic;
-}).call(this,require("buffer").Buffer)
-},{"bn.js":196,"buffer":227}],303:[function(require,module,exports){
-module.exports = function xor(a, b) {
-  var len = a.length;
-  var i = -1;
+},{"./mgf":305,"./withPublic":308,"./xor":309,"bn.js":202,"browserify-rsa":225,"create-hash":237,"parse-asn1":296,"randombytes":310,"safe-buffer":326}],308:[function(require,module,exports){
+var BN = require('bn.js')
+var Buffer = require('safe-buffer').Buffer
+
+function withPublic (paddedMsg, key) {
+  return Buffer.from(paddedMsg
+    .toRed(BN.mont(key.modulus))
+    .redPow(new BN(key.publicExponent))
+    .fromRed()
+    .toArray())
+}
+
+module.exports = withPublic
+
+},{"bn.js":202,"safe-buffer":326}],309:[function(require,module,exports){
+module.exports = function xor (a, b) {
+  var len = a.length
+  var i = -1
   while (++i < len) {
-    a[i] ^= b[i];
+    a[i] ^= b[i]
   }
   return a
-};
-},{}],304:[function(require,module,exports){
+}
+
+},{}],310:[function(require,module,exports){
 (function (process,global){
 'use strict'
 
@@ -46240,7 +47096,7 @@ function randomBytes (size, cb) {
 }
 
 }).call(this,require('_process'),typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"_process":297,"safe-buffer":320}],305:[function(require,module,exports){
+},{"_process":303,"safe-buffer":326}],311:[function(require,module,exports){
 (function (process,global){
 'use strict'
 
@@ -46352,10 +47208,10 @@ function randomFillSync (buf, offset, size) {
 }
 
 }).call(this,require('_process'),typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"_process":297,"randombytes":304,"safe-buffer":320}],306:[function(require,module,exports){
+},{"_process":303,"randombytes":310,"safe-buffer":326}],312:[function(require,module,exports){
 module.exports = require('./lib/_stream_duplex.js');
 
-},{"./lib/_stream_duplex.js":307}],307:[function(require,module,exports){
+},{"./lib/_stream_duplex.js":313}],313:[function(require,module,exports){
 // Copyright Joyent, Inc. and other Node contributors.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
@@ -46487,7 +47343,7 @@ Duplex.prototype._destroy = function (err, cb) {
 
   pna.nextTick(cb, err);
 };
-},{"./_stream_readable":309,"./_stream_writable":311,"core-util-is":229,"inherits":279,"process-nextick-args":296}],308:[function(require,module,exports){
+},{"./_stream_readable":315,"./_stream_writable":317,"core-util-is":235,"inherits":285,"process-nextick-args":302}],314:[function(require,module,exports){
 // Copyright Joyent, Inc. and other Node contributors.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
@@ -46535,7 +47391,7 @@ function PassThrough(options) {
 PassThrough.prototype._transform = function (chunk, encoding, cb) {
   cb(null, chunk);
 };
-},{"./_stream_transform":310,"core-util-is":229,"inherits":279}],309:[function(require,module,exports){
+},{"./_stream_transform":316,"core-util-is":235,"inherits":285}],315:[function(require,module,exports){
 (function (process,global){
 // Copyright Joyent, Inc. and other Node contributors.
 //
@@ -47557,7 +48413,7 @@ function indexOf(xs, x) {
   return -1;
 }
 }).call(this,require('_process'),typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./_stream_duplex":307,"./internal/streams/BufferList":312,"./internal/streams/destroy":313,"./internal/streams/stream":314,"_process":297,"core-util-is":229,"events":262,"inherits":279,"isarray":281,"process-nextick-args":296,"safe-buffer":320,"string_decoder/":330,"util":198}],310:[function(require,module,exports){
+},{"./_stream_duplex":313,"./internal/streams/BufferList":318,"./internal/streams/destroy":319,"./internal/streams/stream":320,"_process":303,"core-util-is":235,"events":268,"inherits":285,"isarray":287,"process-nextick-args":302,"safe-buffer":326,"string_decoder/":336,"util":204}],316:[function(require,module,exports){
 // Copyright Joyent, Inc. and other Node contributors.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
@@ -47772,8 +48628,8 @@ function done(stream, er, data) {
 
   return stream.push(null);
 }
-},{"./_stream_duplex":307,"core-util-is":229,"inherits":279}],311:[function(require,module,exports){
-(function (process,global){
+},{"./_stream_duplex":313,"core-util-is":235,"inherits":285}],317:[function(require,module,exports){
+(function (process,global,setImmediate){
 // Copyright Joyent, Inc. and other Node contributors.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
@@ -48461,8 +49317,8 @@ Writable.prototype._destroy = function (err, cb) {
   this.end();
   cb(err);
 };
-}).call(this,require('_process'),typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./_stream_duplex":307,"./internal/streams/destroy":313,"./internal/streams/stream":314,"_process":297,"core-util-is":229,"inherits":279,"process-nextick-args":296,"safe-buffer":320,"util-deprecate":331}],312:[function(require,module,exports){
+}).call(this,require('_process'),typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {},require("timers").setImmediate)
+},{"./_stream_duplex":313,"./internal/streams/destroy":319,"./internal/streams/stream":320,"_process":303,"core-util-is":235,"inherits":285,"process-nextick-args":302,"safe-buffer":326,"timers":337,"util-deprecate":338}],318:[function(require,module,exports){
 'use strict';
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -48542,7 +49398,7 @@ if (util && util.inspect && util.inspect.custom) {
     return this.constructor.name + ' ' + obj;
   };
 }
-},{"safe-buffer":320,"util":198}],313:[function(require,module,exports){
+},{"safe-buffer":326,"util":204}],319:[function(require,module,exports){
 'use strict';
 
 /*<replacement>*/
@@ -48617,13 +49473,13 @@ module.exports = {
   destroy: destroy,
   undestroy: undestroy
 };
-},{"process-nextick-args":296}],314:[function(require,module,exports){
+},{"process-nextick-args":302}],320:[function(require,module,exports){
 module.exports = require('events').EventEmitter;
 
-},{"events":262}],315:[function(require,module,exports){
+},{"events":268}],321:[function(require,module,exports){
 module.exports = require('./readable').PassThrough
 
-},{"./readable":316}],316:[function(require,module,exports){
+},{"./readable":322}],322:[function(require,module,exports){
 exports = module.exports = require('./lib/_stream_readable.js');
 exports.Stream = exports;
 exports.Readable = exports;
@@ -48632,33 +49488,33 @@ exports.Duplex = require('./lib/_stream_duplex.js');
 exports.Transform = require('./lib/_stream_transform.js');
 exports.PassThrough = require('./lib/_stream_passthrough.js');
 
-},{"./lib/_stream_duplex.js":307,"./lib/_stream_passthrough.js":308,"./lib/_stream_readable.js":309,"./lib/_stream_transform.js":310,"./lib/_stream_writable.js":311}],317:[function(require,module,exports){
+},{"./lib/_stream_duplex.js":313,"./lib/_stream_passthrough.js":314,"./lib/_stream_readable.js":315,"./lib/_stream_transform.js":316,"./lib/_stream_writable.js":317}],323:[function(require,module,exports){
 module.exports = require('./readable').Transform
 
-},{"./readable":316}],318:[function(require,module,exports){
+},{"./readable":322}],324:[function(require,module,exports){
 module.exports = require('./lib/_stream_writable.js');
 
-},{"./lib/_stream_writable.js":311}],319:[function(require,module,exports){
-arguments[4][130][0].apply(exports,arguments)
-},{"buffer":227,"dup":130,"hash-base":264,"inherits":279}],320:[function(require,module,exports){
-arguments[4][131][0].apply(exports,arguments)
-},{"buffer":227,"dup":131}],321:[function(require,module,exports){
+},{"./lib/_stream_writable.js":317}],325:[function(require,module,exports){
 arguments[4][133][0].apply(exports,arguments)
-},{"dup":133,"safe-buffer":320}],322:[function(require,module,exports){
+},{"buffer":233,"dup":133,"hash-base":270,"inherits":285}],326:[function(require,module,exports){
 arguments[4][134][0].apply(exports,arguments)
-},{"./sha":323,"./sha1":324,"./sha224":325,"./sha256":326,"./sha384":327,"./sha512":328,"dup":134}],323:[function(require,module,exports){
-arguments[4][135][0].apply(exports,arguments)
-},{"./hash":321,"dup":135,"inherits":279,"safe-buffer":320}],324:[function(require,module,exports){
+},{"buffer":233,"dup":134}],327:[function(require,module,exports){
 arguments[4][136][0].apply(exports,arguments)
-},{"./hash":321,"dup":136,"inherits":279,"safe-buffer":320}],325:[function(require,module,exports){
+},{"dup":136,"safe-buffer":326}],328:[function(require,module,exports){
 arguments[4][137][0].apply(exports,arguments)
-},{"./hash":321,"./sha256":326,"dup":137,"inherits":279,"safe-buffer":320}],326:[function(require,module,exports){
+},{"./sha":329,"./sha1":330,"./sha224":331,"./sha256":332,"./sha384":333,"./sha512":334,"dup":137}],329:[function(require,module,exports){
 arguments[4][138][0].apply(exports,arguments)
-},{"./hash":321,"dup":138,"inherits":279,"safe-buffer":320}],327:[function(require,module,exports){
+},{"./hash":327,"dup":138,"inherits":285,"safe-buffer":326}],330:[function(require,module,exports){
 arguments[4][139][0].apply(exports,arguments)
-},{"./hash":321,"./sha512":328,"dup":139,"inherits":279,"safe-buffer":320}],328:[function(require,module,exports){
+},{"./hash":327,"dup":139,"inherits":285,"safe-buffer":326}],331:[function(require,module,exports){
 arguments[4][140][0].apply(exports,arguments)
-},{"./hash":321,"dup":140,"inherits":279,"safe-buffer":320}],329:[function(require,module,exports){
+},{"./hash":327,"./sha256":332,"dup":140,"inherits":285,"safe-buffer":326}],332:[function(require,module,exports){
+arguments[4][141][0].apply(exports,arguments)
+},{"./hash":327,"dup":141,"inherits":285,"safe-buffer":326}],333:[function(require,module,exports){
+arguments[4][142][0].apply(exports,arguments)
+},{"./hash":327,"./sha512":334,"dup":142,"inherits":285,"safe-buffer":326}],334:[function(require,module,exports){
+arguments[4][143][0].apply(exports,arguments)
+},{"./hash":327,"dup":143,"inherits":285,"safe-buffer":326}],335:[function(require,module,exports){
 // Copyright Joyent, Inc. and other Node contributors.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
@@ -48787,7 +49643,7 @@ Stream.prototype.pipe = function(dest, options) {
   return dest;
 };
 
-},{"events":262,"inherits":279,"readable-stream/duplex.js":306,"readable-stream/passthrough.js":315,"readable-stream/readable.js":316,"readable-stream/transform.js":317,"readable-stream/writable.js":318}],330:[function(require,module,exports){
+},{"events":268,"inherits":285,"readable-stream/duplex.js":312,"readable-stream/passthrough.js":321,"readable-stream/readable.js":322,"readable-stream/transform.js":323,"readable-stream/writable.js":324}],336:[function(require,module,exports){
 // Copyright Joyent, Inc. and other Node contributors.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
@@ -49084,7 +49940,86 @@ function simpleWrite(buf) {
 function simpleEnd(buf) {
   return buf && buf.length ? this.write(buf) : '';
 }
-},{"safe-buffer":320}],331:[function(require,module,exports){
+},{"safe-buffer":326}],337:[function(require,module,exports){
+(function (setImmediate,clearImmediate){
+var nextTick = require('process/browser.js').nextTick;
+var apply = Function.prototype.apply;
+var slice = Array.prototype.slice;
+var immediateIds = {};
+var nextImmediateId = 0;
+
+// DOM APIs, for completeness
+
+exports.setTimeout = function() {
+  return new Timeout(apply.call(setTimeout, window, arguments), clearTimeout);
+};
+exports.setInterval = function() {
+  return new Timeout(apply.call(setInterval, window, arguments), clearInterval);
+};
+exports.clearTimeout =
+exports.clearInterval = function(timeout) { timeout.close(); };
+
+function Timeout(id, clearFn) {
+  this._id = id;
+  this._clearFn = clearFn;
+}
+Timeout.prototype.unref = Timeout.prototype.ref = function() {};
+Timeout.prototype.close = function() {
+  this._clearFn.call(window, this._id);
+};
+
+// Does not start the time, just sets up the members needed.
+exports.enroll = function(item, msecs) {
+  clearTimeout(item._idleTimeoutId);
+  item._idleTimeout = msecs;
+};
+
+exports.unenroll = function(item) {
+  clearTimeout(item._idleTimeoutId);
+  item._idleTimeout = -1;
+};
+
+exports._unrefActive = exports.active = function(item) {
+  clearTimeout(item._idleTimeoutId);
+
+  var msecs = item._idleTimeout;
+  if (msecs >= 0) {
+    item._idleTimeoutId = setTimeout(function onTimeout() {
+      if (item._onTimeout)
+        item._onTimeout();
+    }, msecs);
+  }
+};
+
+// That's not how node.js implements it but the exposed api is the same.
+exports.setImmediate = typeof setImmediate === "function" ? setImmediate : function(fn) {
+  var id = nextImmediateId++;
+  var args = arguments.length < 2 ? false : slice.call(arguments, 1);
+
+  immediateIds[id] = true;
+
+  nextTick(function onNextTick() {
+    if (immediateIds[id]) {
+      // fn.call() is faster so we optimize for the common use-case
+      // @see http://jsperf.com/call-apply-segu
+      if (args) {
+        fn.apply(null, args);
+      } else {
+        fn.call(null);
+      }
+      // Prevent ids from leaking
+      exports.clearImmediate(id);
+    }
+  });
+
+  return id;
+};
+
+exports.clearImmediate = typeof clearImmediate === "function" ? clearImmediate : function(id) {
+  delete immediateIds[id];
+};
+}).call(this,require("timers").setImmediate,require("timers").clearImmediate)
+},{"process/browser.js":303,"timers":337}],338:[function(require,module,exports){
 (function (global){
 
 /**
@@ -49155,606 +50090,7 @@ function config (name) {
 }
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{}],332:[function(require,module,exports){
-arguments[4][46][0].apply(exports,arguments)
-},{"dup":46}],333:[function(require,module,exports){
-module.exports = function isBuffer(arg) {
-  return arg && typeof arg === 'object'
-    && typeof arg.copy === 'function'
-    && typeof arg.fill === 'function'
-    && typeof arg.readUInt8 === 'function';
-}
-},{}],334:[function(require,module,exports){
-(function (process,global){
-// Copyright Joyent, Inc. and other Node contributors.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a
-// copy of this software and associated documentation files (the
-// "Software"), to deal in the Software without restriction, including
-// without limitation the rights to use, copy, modify, merge, publish,
-// distribute, sublicense, and/or sell copies of the Software, and to permit
-// persons to whom the Software is furnished to do so, subject to the
-// following conditions:
-//
-// The above copyright notice and this permission notice shall be included
-// in all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
-// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
-// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
-// USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-var formatRegExp = /%[sdj%]/g;
-exports.format = function(f) {
-  if (!isString(f)) {
-    var objects = [];
-    for (var i = 0; i < arguments.length; i++) {
-      objects.push(inspect(arguments[i]));
-    }
-    return objects.join(' ');
-  }
-
-  var i = 1;
-  var args = arguments;
-  var len = args.length;
-  var str = String(f).replace(formatRegExp, function(x) {
-    if (x === '%%') return '%';
-    if (i >= len) return x;
-    switch (x) {
-      case '%s': return String(args[i++]);
-      case '%d': return Number(args[i++]);
-      case '%j':
-        try {
-          return JSON.stringify(args[i++]);
-        } catch (_) {
-          return '[Circular]';
-        }
-      default:
-        return x;
-    }
-  });
-  for (var x = args[i]; i < len; x = args[++i]) {
-    if (isNull(x) || !isObject(x)) {
-      str += ' ' + x;
-    } else {
-      str += ' ' + inspect(x);
-    }
-  }
-  return str;
-};
-
-
-// Mark that a method should not be used.
-// Returns a modified function which warns once by default.
-// If --no-deprecation is set, then it is a no-op.
-exports.deprecate = function(fn, msg) {
-  // Allow for deprecating things in the process of starting up.
-  if (isUndefined(global.process)) {
-    return function() {
-      return exports.deprecate(fn, msg).apply(this, arguments);
-    };
-  }
-
-  if (process.noDeprecation === true) {
-    return fn;
-  }
-
-  var warned = false;
-  function deprecated() {
-    if (!warned) {
-      if (process.throwDeprecation) {
-        throw new Error(msg);
-      } else if (process.traceDeprecation) {
-        console.trace(msg);
-      } else {
-        console.error(msg);
-      }
-      warned = true;
-    }
-    return fn.apply(this, arguments);
-  }
-
-  return deprecated;
-};
-
-
-var debugs = {};
-var debugEnviron;
-exports.debuglog = function(set) {
-  if (isUndefined(debugEnviron))
-    debugEnviron = process.env.NODE_DEBUG || '';
-  set = set.toUpperCase();
-  if (!debugs[set]) {
-    if (new RegExp('\\b' + set + '\\b', 'i').test(debugEnviron)) {
-      var pid = process.pid;
-      debugs[set] = function() {
-        var msg = exports.format.apply(exports, arguments);
-        console.error('%s %d: %s', set, pid, msg);
-      };
-    } else {
-      debugs[set] = function() {};
-    }
-  }
-  return debugs[set];
-};
-
-
-/**
- * Echos the value of a value. Trys to print the value out
- * in the best way possible given the different types.
- *
- * @param {Object} obj The object to print out.
- * @param {Object} opts Optional options object that alters the output.
- */
-/* legacy: obj, showHidden, depth, colors*/
-function inspect(obj, opts) {
-  // default options
-  var ctx = {
-    seen: [],
-    stylize: stylizeNoColor
-  };
-  // legacy...
-  if (arguments.length >= 3) ctx.depth = arguments[2];
-  if (arguments.length >= 4) ctx.colors = arguments[3];
-  if (isBoolean(opts)) {
-    // legacy...
-    ctx.showHidden = opts;
-  } else if (opts) {
-    // got an "options" object
-    exports._extend(ctx, opts);
-  }
-  // set default options
-  if (isUndefined(ctx.showHidden)) ctx.showHidden = false;
-  if (isUndefined(ctx.depth)) ctx.depth = 2;
-  if (isUndefined(ctx.colors)) ctx.colors = false;
-  if (isUndefined(ctx.customInspect)) ctx.customInspect = true;
-  if (ctx.colors) ctx.stylize = stylizeWithColor;
-  return formatValue(ctx, obj, ctx.depth);
-}
-exports.inspect = inspect;
-
-
-// http://en.wikipedia.org/wiki/ANSI_escape_code#graphics
-inspect.colors = {
-  'bold' : [1, 22],
-  'italic' : [3, 23],
-  'underline' : [4, 24],
-  'inverse' : [7, 27],
-  'white' : [37, 39],
-  'grey' : [90, 39],
-  'black' : [30, 39],
-  'blue' : [34, 39],
-  'cyan' : [36, 39],
-  'green' : [32, 39],
-  'magenta' : [35, 39],
-  'red' : [31, 39],
-  'yellow' : [33, 39]
-};
-
-// Don't use 'blue' not visible on cmd.exe
-inspect.styles = {
-  'special': 'cyan',
-  'number': 'yellow',
-  'boolean': 'yellow',
-  'undefined': 'grey',
-  'null': 'bold',
-  'string': 'green',
-  'date': 'magenta',
-  // "name": intentionally not styling
-  'regexp': 'red'
-};
-
-
-function stylizeWithColor(str, styleType) {
-  var style = inspect.styles[styleType];
-
-  if (style) {
-    return '\u001b[' + inspect.colors[style][0] + 'm' + str +
-           '\u001b[' + inspect.colors[style][1] + 'm';
-  } else {
-    return str;
-  }
-}
-
-
-function stylizeNoColor(str, styleType) {
-  return str;
-}
-
-
-function arrayToHash(array) {
-  var hash = {};
-
-  array.forEach(function(val, idx) {
-    hash[val] = true;
-  });
-
-  return hash;
-}
-
-
-function formatValue(ctx, value, recurseTimes) {
-  // Provide a hook for user-specified inspect functions.
-  // Check that value is an object with an inspect function on it
-  if (ctx.customInspect &&
-      value &&
-      isFunction(value.inspect) &&
-      // Filter out the util module, it's inspect function is special
-      value.inspect !== exports.inspect &&
-      // Also filter out any prototype objects using the circular check.
-      !(value.constructor && value.constructor.prototype === value)) {
-    var ret = value.inspect(recurseTimes, ctx);
-    if (!isString(ret)) {
-      ret = formatValue(ctx, ret, recurseTimes);
-    }
-    return ret;
-  }
-
-  // Primitive types cannot have properties
-  var primitive = formatPrimitive(ctx, value);
-  if (primitive) {
-    return primitive;
-  }
-
-  // Look up the keys of the object.
-  var keys = Object.keys(value);
-  var visibleKeys = arrayToHash(keys);
-
-  if (ctx.showHidden) {
-    keys = Object.getOwnPropertyNames(value);
-  }
-
-  // IE doesn't make error fields non-enumerable
-  // http://msdn.microsoft.com/en-us/library/ie/dww52sbt(v=vs.94).aspx
-  if (isError(value)
-      && (keys.indexOf('message') >= 0 || keys.indexOf('description') >= 0)) {
-    return formatError(value);
-  }
-
-  // Some type of object without properties can be shortcutted.
-  if (keys.length === 0) {
-    if (isFunction(value)) {
-      var name = value.name ? ': ' + value.name : '';
-      return ctx.stylize('[Function' + name + ']', 'special');
-    }
-    if (isRegExp(value)) {
-      return ctx.stylize(RegExp.prototype.toString.call(value), 'regexp');
-    }
-    if (isDate(value)) {
-      return ctx.stylize(Date.prototype.toString.call(value), 'date');
-    }
-    if (isError(value)) {
-      return formatError(value);
-    }
-  }
-
-  var base = '', array = false, braces = ['{', '}'];
-
-  // Make Array say that they are Array
-  if (isArray(value)) {
-    array = true;
-    braces = ['[', ']'];
-  }
-
-  // Make functions say that they are functions
-  if (isFunction(value)) {
-    var n = value.name ? ': ' + value.name : '';
-    base = ' [Function' + n + ']';
-  }
-
-  // Make RegExps say that they are RegExps
-  if (isRegExp(value)) {
-    base = ' ' + RegExp.prototype.toString.call(value);
-  }
-
-  // Make dates with properties first say the date
-  if (isDate(value)) {
-    base = ' ' + Date.prototype.toUTCString.call(value);
-  }
-
-  // Make error with message first say the error
-  if (isError(value)) {
-    base = ' ' + formatError(value);
-  }
-
-  if (keys.length === 0 && (!array || value.length == 0)) {
-    return braces[0] + base + braces[1];
-  }
-
-  if (recurseTimes < 0) {
-    if (isRegExp(value)) {
-      return ctx.stylize(RegExp.prototype.toString.call(value), 'regexp');
-    } else {
-      return ctx.stylize('[Object]', 'special');
-    }
-  }
-
-  ctx.seen.push(value);
-
-  var output;
-  if (array) {
-    output = formatArray(ctx, value, recurseTimes, visibleKeys, keys);
-  } else {
-    output = keys.map(function(key) {
-      return formatProperty(ctx, value, recurseTimes, visibleKeys, key, array);
-    });
-  }
-
-  ctx.seen.pop();
-
-  return reduceToSingleString(output, base, braces);
-}
-
-
-function formatPrimitive(ctx, value) {
-  if (isUndefined(value))
-    return ctx.stylize('undefined', 'undefined');
-  if (isString(value)) {
-    var simple = '\'' + JSON.stringify(value).replace(/^"|"$/g, '')
-                                             .replace(/'/g, "\\'")
-                                             .replace(/\\"/g, '"') + '\'';
-    return ctx.stylize(simple, 'string');
-  }
-  if (isNumber(value))
-    return ctx.stylize('' + value, 'number');
-  if (isBoolean(value))
-    return ctx.stylize('' + value, 'boolean');
-  // For some reason typeof null is "object", so special case here.
-  if (isNull(value))
-    return ctx.stylize('null', 'null');
-}
-
-
-function formatError(value) {
-  return '[' + Error.prototype.toString.call(value) + ']';
-}
-
-
-function formatArray(ctx, value, recurseTimes, visibleKeys, keys) {
-  var output = [];
-  for (var i = 0, l = value.length; i < l; ++i) {
-    if (hasOwnProperty(value, String(i))) {
-      output.push(formatProperty(ctx, value, recurseTimes, visibleKeys,
-          String(i), true));
-    } else {
-      output.push('');
-    }
-  }
-  keys.forEach(function(key) {
-    if (!key.match(/^\d+$/)) {
-      output.push(formatProperty(ctx, value, recurseTimes, visibleKeys,
-          key, true));
-    }
-  });
-  return output;
-}
-
-
-function formatProperty(ctx, value, recurseTimes, visibleKeys, key, array) {
-  var name, str, desc;
-  desc = Object.getOwnPropertyDescriptor(value, key) || { value: value[key] };
-  if (desc.get) {
-    if (desc.set) {
-      str = ctx.stylize('[Getter/Setter]', 'special');
-    } else {
-      str = ctx.stylize('[Getter]', 'special');
-    }
-  } else {
-    if (desc.set) {
-      str = ctx.stylize('[Setter]', 'special');
-    }
-  }
-  if (!hasOwnProperty(visibleKeys, key)) {
-    name = '[' + key + ']';
-  }
-  if (!str) {
-    if (ctx.seen.indexOf(desc.value) < 0) {
-      if (isNull(recurseTimes)) {
-        str = formatValue(ctx, desc.value, null);
-      } else {
-        str = formatValue(ctx, desc.value, recurseTimes - 1);
-      }
-      if (str.indexOf('\n') > -1) {
-        if (array) {
-          str = str.split('\n').map(function(line) {
-            return '  ' + line;
-          }).join('\n').substr(2);
-        } else {
-          str = '\n' + str.split('\n').map(function(line) {
-            return '   ' + line;
-          }).join('\n');
-        }
-      }
-    } else {
-      str = ctx.stylize('[Circular]', 'special');
-    }
-  }
-  if (isUndefined(name)) {
-    if (array && key.match(/^\d+$/)) {
-      return str;
-    }
-    name = JSON.stringify('' + key);
-    if (name.match(/^"([a-zA-Z_][a-zA-Z_0-9]*)"$/)) {
-      name = name.substr(1, name.length - 2);
-      name = ctx.stylize(name, 'name');
-    } else {
-      name = name.replace(/'/g, "\\'")
-                 .replace(/\\"/g, '"')
-                 .replace(/(^"|"$)/g, "'");
-      name = ctx.stylize(name, 'string');
-    }
-  }
-
-  return name + ': ' + str;
-}
-
-
-function reduceToSingleString(output, base, braces) {
-  var numLinesEst = 0;
-  var length = output.reduce(function(prev, cur) {
-    numLinesEst++;
-    if (cur.indexOf('\n') >= 0) numLinesEst++;
-    return prev + cur.replace(/\u001b\[\d\d?m/g, '').length + 1;
-  }, 0);
-
-  if (length > 60) {
-    return braces[0] +
-           (base === '' ? '' : base + '\n ') +
-           ' ' +
-           output.join(',\n  ') +
-           ' ' +
-           braces[1];
-  }
-
-  return braces[0] + base + ' ' + output.join(', ') + ' ' + braces[1];
-}
-
-
-// NOTE: These type checking functions intentionally don't use `instanceof`
-// because it is fragile and can be easily faked with `Object.create()`.
-function isArray(ar) {
-  return Array.isArray(ar);
-}
-exports.isArray = isArray;
-
-function isBoolean(arg) {
-  return typeof arg === 'boolean';
-}
-exports.isBoolean = isBoolean;
-
-function isNull(arg) {
-  return arg === null;
-}
-exports.isNull = isNull;
-
-function isNullOrUndefined(arg) {
-  return arg == null;
-}
-exports.isNullOrUndefined = isNullOrUndefined;
-
-function isNumber(arg) {
-  return typeof arg === 'number';
-}
-exports.isNumber = isNumber;
-
-function isString(arg) {
-  return typeof arg === 'string';
-}
-exports.isString = isString;
-
-function isSymbol(arg) {
-  return typeof arg === 'symbol';
-}
-exports.isSymbol = isSymbol;
-
-function isUndefined(arg) {
-  return arg === void 0;
-}
-exports.isUndefined = isUndefined;
-
-function isRegExp(re) {
-  return isObject(re) && objectToString(re) === '[object RegExp]';
-}
-exports.isRegExp = isRegExp;
-
-function isObject(arg) {
-  return typeof arg === 'object' && arg !== null;
-}
-exports.isObject = isObject;
-
-function isDate(d) {
-  return isObject(d) && objectToString(d) === '[object Date]';
-}
-exports.isDate = isDate;
-
-function isError(e) {
-  return isObject(e) &&
-      (objectToString(e) === '[object Error]' || e instanceof Error);
-}
-exports.isError = isError;
-
-function isFunction(arg) {
-  return typeof arg === 'function';
-}
-exports.isFunction = isFunction;
-
-function isPrimitive(arg) {
-  return arg === null ||
-         typeof arg === 'boolean' ||
-         typeof arg === 'number' ||
-         typeof arg === 'string' ||
-         typeof arg === 'symbol' ||  // ES6 symbol
-         typeof arg === 'undefined';
-}
-exports.isPrimitive = isPrimitive;
-
-exports.isBuffer = require('./support/isBuffer');
-
-function objectToString(o) {
-  return Object.prototype.toString.call(o);
-}
-
-
-function pad(n) {
-  return n < 10 ? '0' + n.toString(10) : n.toString(10);
-}
-
-
-var months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep',
-              'Oct', 'Nov', 'Dec'];
-
-// 26 Feb 16:19:34
-function timestamp() {
-  var d = new Date();
-  var time = [pad(d.getHours()),
-              pad(d.getMinutes()),
-              pad(d.getSeconds())].join(':');
-  return [d.getDate(), months[d.getMonth()], time].join(' ');
-}
-
-
-// log is just a thin wrapper to console.log that prepends a timestamp
-exports.log = function() {
-  console.log('%s - %s', timestamp(), exports.format.apply(exports, arguments));
-};
-
-
-/**
- * Inherit the prototype methods from one constructor into another.
- *
- * The Function.prototype.inherits from lang.js rewritten as a standalone
- * function (not on Function.prototype). NOTE: If this file is to be loaded
- * during bootstrapping this function needs to be rewritten using some native
- * functions as prototype setup using normal JavaScript does not work as
- * expected during bootstrapping (see mirror.js in r114903).
- *
- * @param {function} ctor Constructor function which needs to inherit the
- *     prototype.
- * @param {function} superCtor Constructor function to inherit prototype from.
- */
-exports.inherits = require('inherits');
-
-exports._extend = function(origin, add) {
-  // Don't do anything if add isn't an object
-  if (!add || !isObject(add)) return origin;
-
-  var keys = Object.keys(add);
-  var i = keys.length;
-  while (i--) {
-    origin[keys[i]] = add[keys[i]];
-  }
-  return origin;
-};
-
-function hasOwnProperty(obj, prop) {
-  return Object.prototype.hasOwnProperty.call(obj, prop);
-}
-
-}).call(this,require('_process'),typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./support/isBuffer":333,"_process":297,"inherits":332}],335:[function(require,module,exports){
+},{}],339:[function(require,module,exports){
 var indexOf = function (xs, item) {
     if (xs.indexOf) return xs.indexOf(item);
     else for (var i = 0; i < xs.length; i++) {
@@ -49814,13 +50150,13 @@ Script.prototype.runInContext = function (context) {
     if (!(context instanceof Context)) {
         throw new TypeError("needs a 'context' argument.");
     }
-
+    
     var iframe = document.createElement('iframe');
     if (!iframe.style) iframe.style = {};
     iframe.style.display = 'none';
-
+    
     document.body.appendChild(iframe);
-
+    
     var win = iframe.contentWindow;
     var wEval = win.eval, wExecScript = win.execScript;
 
@@ -49829,7 +50165,7 @@ Script.prototype.runInContext = function (context) {
         wExecScript.call(win, 'null');
         wEval = win.eval;
     }
-
+    
     forEach(Object_keys(context), function (key) {
         win[key] = context[key];
     });
@@ -49838,11 +50174,11 @@ Script.prototype.runInContext = function (context) {
             win[key] = context[key];
         }
     });
-
+    
     var winKeys = Object_keys(win);
 
     var res = wEval.call(win, this.code);
-
+    
     forEach(Object_keys(win), function (key) {
         // Avoid copying circular objects like `top` and `window` by only
         // updating existing context properties or new properties in the `win`
@@ -49857,9 +50193,9 @@ Script.prototype.runInContext = function (context) {
             defineProp(context, key, win[key]);
         }
     });
-
+    
     document.body.removeChild(iframe);
-
+    
     return res;
 };
 
@@ -49886,6 +50222,10 @@ forEach(Object_keys(Script.prototype), function (name) {
         return s[name].apply(s, [].slice.call(arguments, 1));
     };
 });
+
+exports.isContext = function (context) {
+    return context instanceof Context;
+};
 
 exports.createScript = function (code) {
     return exports.Script(code);

--- a/decode_wrapper/decode_wrapper.js
+++ b/decode_wrapper/decode_wrapper.js
@@ -4,5 +4,25 @@ var steem = require('steem');
 
 window.decodeMemo = (e,r) => steem.memo.decode(e,r);
 window.encodeMemo = (e,r,a) => steem.memo.encode(e,r,a);
-window.signBuffer = (e,r) => signature.Signature.signBuffer(e,r).toHex();
+window.signBuffer = (e,r) => {
+    // try to parse Buffer
+    let buf = e;
+    try {
+        const o = JSON.parse(buf, (k, v) => {
+            if (v !== null
+                && typeof v === 'object'
+                && 'type' in v
+                && v.type === 'Buffer'
+                && 'data' in v
+                && Array.isArray(v.data)) {
+              return new Buffer(v.data);
+            }
+            return v;
+        });
+        if (Buffer.isBuffer(o)) {
+          buf = o;
+        }
+    } catch (e) {}
+    return signature.Signature.signBuffer(buf,r).toHex();
+}
 window.signedCall = (m,p,a,k,c) => steem.api.signedCall(m,p,a,k,c);

--- a/js/dialog.js
+++ b/js/dialog.js
@@ -110,11 +110,22 @@ chrome.runtime.onMessage.addListener(function(msg, sender, sendResp) {
             case "signBuffer":
               $("#dialog_message").show();
               $("#dialog_message").text('The website ' + msg.domain + ' would like you to sign a message using the ' + msg.data.method + ' key for the account: @' + msg.data.username);
-              let truncatedMessage = msg.data.message.substring(0, 200);
-              if (msg.data.message.length > 200) {
-                  truncatedMessage += '...';
+              const fullMessage = msg.data.message;
+              let truncatedMessage = fullMessage.substring(0, 200);
+              if (fullMessage.length > 200) {
+                  truncatedMessage += '...(click to expand)';
               }
+              let expanded = false;
               $("#message_sign").text(truncatedMessage);
+              $("#message_sign").click(function() {
+                  if (expanded) {
+                      $("#message_sign").text(truncatedMessage);
+                      expanded = false;
+                  } else {
+                      $("#message_sign").text(fullMessage);
+                      expanded = true;
+                  }
+              });
                 break;
             case "broadcast":
                 $("#custom_data").click(function() {

--- a/js/dialog.js
+++ b/js/dialog.js
@@ -110,7 +110,11 @@ chrome.runtime.onMessage.addListener(function(msg, sender, sendResp) {
             case "signBuffer":
               $("#dialog_message").show();
               $("#dialog_message").text('The website ' + msg.domain + ' would like you to sign a message using the ' + msg.data.method + ' key for the account: @' + msg.data.username);
-              $("#message_sign").text(msg.data.message);
+              let truncatedMessage = msg.data.message.substring(0, 200);
+              if (msg.data.message.length > 200) {
+                  truncatedMessage += '...';
+              }
+              $("#message_sign").text(truncatedMessage);
                 break;
             case "broadcast":
                 $("#custom_data").click(function() {


### PR DESCRIPTION
Added functionality to allow passing in of JSON-stringified Node-js Buffer. Also in the dialog will truncate the message, otherwise the dialog will freeze while a large buffer is being displayed.

Need the browserified decode.min.js to be re-generated and placed into the vendor folder.

Usage:

```
window.steem_keychain.requestSignBuffer(
                username,
                JSON.stringify(buf),
                'Posting',
                response => {
                    resolve(response);
                }
            );
```

where `buf` is a Buffer object.

Used for example in condenser where an image URL is being signed based on the payload buffer.