### PR TITLE
Add username choice for sign buffer requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ Sites can request that the extension sign and broadcast a transfer operation for
 ```
 steem_keychain.requestTransfer(account_name, to_account, amount, memo, currency, function(response) {
 	console.log(response);
-},enforce);
+}, enforce);
 ```
-where `memo` will be encrypted using Memo key if it is starting by `#`, and `enforce` doesn't allow the user to chose which account will make the transfer but rather enforce `account_name`.
+where `memo` will be encrypted using Memo key if it is starting by `#`, and `enforce` doesn't allow the user to chose which account will make the transfer but rather enforce `account_name` (optional, defaults to false).
 
 ### Decode Memo / Verify Key
 
@@ -129,10 +129,12 @@ Sites can request that the extension sign messages:
 ```
 steem_keychain.requestSignBuffer(account_name, message, key_type, function(response) {
         console.log(response);
-});
+}, enforce);
 ```
 
-Where "message" is any string and "key_type" can be "Posting" or "Active". This is equivalent to
+Where "message" is any string and "key_type" can be "Posting" or "Active", and `enforce` doesn't allow the user to chose which account will make the request but rather enforce `account_name` (optional, defaults to false).
+
+. This is equivalent to
 
 ```Signature.signBufferSha256(hash.sha256(message), wif).toHex();```
 

--- a/css/dialog.css
+++ b/css/dialog.css
@@ -96,7 +96,7 @@ h3 .small {
 
 #modal-body-msg .msg-data>div,
 #modal-body-msg .msg-data>h3,
-#transfer_acct_list {
+#acct_list {
     display: none;
 }
 

--- a/example/main.html
+++ b/example/main.html
@@ -57,6 +57,7 @@
     <h3>Sign message</h3>
     <input type="text" placeholder="username" id="sign_username" />
     <input type="text" placeholder="message" id="sign_message" />
+    <input type="checkbox" id="sign_enforce" /><label for="sign_enforce">Enforce username</label>
     <select id="sign_method">
       <option>Memo</option>
       <option>Posting</option>
@@ -70,7 +71,7 @@
       <option>Posting</option>
       <option>Active</option>
     </select>
-    <input type="number" placeholder="1" id="addauth_weight" />
+    <input type="number" placeholder="1" id="addauth_weight" value=1 />
     <button id="send_addauth">Send</button>
     <h3>Remove Account Authority</h3>
     <input type="text" placeholder="username" id="removeauth_username" />

--- a/example/main.js
+++ b/example/main.js
@@ -68,7 +68,7 @@ $("#send_signature").click(function() {
     steem_keychain.requestSignBuffer($("#sign_username").val(), $("#sign_message").val(), $("#sign_method option:selected").text(), function(response) {
         console.log('main js response - sign');
         console.log(response);
-    });
+    }, $("#sign_enforce").is(":checked"));
 });
 
 $("#send_addauth").click(function() {

--- a/html/dialog.html
+++ b/html/dialog.html
@@ -31,14 +31,14 @@
         </div>
 
         <div id="modal-body-msg" style="display: none;">
-            <div id="transfer_acct_list" class="custom-select custom-select-main transfer">
-                <select id="select_transfer">
+            <div id="acct_list" class="custom-select custom-select-main transfer signBuffer">
+                <select id="select_account">
 						</select>
             </div>
 
             <div class="msg-data">
-                <h3 class="decode vote post custom delegation addAccountAuthority removeAccountAuthority broadcast signBuffer signedCall witnessVote powerUp powerDown">Account</h3>
-                <div class="decode vote post custom delegation addAccountAuthority removeAccountAuthority broadcast signBuffer signedCall witnessVote powerUp powerDown" id="username"></div>
+                <h3 class="decode vote post custom delegation addAccountAuthority removeAccountAuthority broadcast signedCall witnessVote powerUp powerDown">Account</h3>
+                <div class="decode vote post custom delegation addAccountAuthority removeAccountAuthority broadcast signedCall witnessVote powerUp powerDown" id="username"></div>
                 <h3 class="decode">Key</h3>
                 <div class="decode" id="wif"></div>
                 <h3 class="vote">Author</h3>

--- a/js/dialog.js
+++ b/js/dialog.js
@@ -80,7 +80,7 @@ chrome.runtime.onMessage.addListener(function(msg, sender, sendResp) {
             $("#dialog_message").text(msg.data.display_msg);
         }
 
-        if (type == "transfer") {
+        if (type == 'transfer' || type == 'signBuffer') {
             $('#modal-body-msg .msg-data').css('max-height', '200px');
             let accounts = msg.accounts;
             if (msg.data.username !== undefined) {
@@ -94,7 +94,7 @@ chrome.runtime.onMessage.addListener(function(msg, sender, sendResp) {
             }
             for (acc of accounts) {
                 if (acc != undefined)
-                    $("#select_transfer").append("<option>" + acc.name + "</option>");
+                    $("#select_account").append("<option>" + acc.name + "</option>");
             }
             initiateCustomSelect();
         }
@@ -122,8 +122,13 @@ chrome.runtime.onMessage.addListener(function(msg, sender, sendResp) {
                 $("#dialog_message").text('The website ' + msg.domain + ' would like to verify that you have access to the private ' + msg.data.method + ' key for the account: @' + msg.data.username);
                 break;
             case "signBuffer":
+                if (msg.data.enforce) {
+                    $("#username").show();
+                    $("#username").prev().show();
+                    $("#acct_list").hide();
+                }
                 $("#dialog_message").show();
-                $("#dialog_message").text('The website ' + msg.domain + ' would like you to sign a message using the ' + msg.data.method + ' key for the account: @' + msg.data.username);
+                $("#dialog_message").text('The website ' + msg.domain + ' would like you to sign a message using the ' + msg.data.method + ' key.');
                 const fullMessage = msg.data.message;
                 let truncatedMessage = fullMessage.substring(0, 200);
                 if (fullMessage.length > 200) {
@@ -185,7 +190,7 @@ chrome.runtime.onMessage.addListener(function(msg, sender, sendResp) {
                 if (enforce) {
                     $("#username").show();
                     $("#username").prev().show();
-                    $("#transfer_acct_list").hide();
+                    $("#acct_list").hide();
                 }
                 $("#to").text('@' + msg.data.to);
                 $("#amount").text(msg.data.amount + " " + msg.data.currency);
@@ -254,8 +259,8 @@ chrome.runtime.onMessage.addListener(function(msg, sender, sendResp) {
         // Closes the window and launch the transaction in background
         $("#proceed").click(function() {
             let data = msg.data;
-            if (data.type == "transfer" && !enforce)
-                data.username = $("#select_transfer option:selected").val();
+            if ((data.type == 'transfer' || data.type == 'signBuffer') && !enforce)
+                data.username = $("#select_account option:selected").val();
             chrome.runtime.sendMessage({
                 command: "acceptTransaction",
                 data: data,

--- a/js/dialog.js
+++ b/js/dialog.js
@@ -105,7 +105,7 @@ chrome.runtime.onMessage.addListener(function(msg, sender, sendResp) {
         $("#modal-content").css("align-items", "flex-start");
         const keyVerifyAction = msg.data.type == 'decode' || msg.data.type == 'signBuffer';
         console.log(msg.data.key);
-        if (msg.data.key!=="active"&&msg.data.type!="transfer") {
+        if (msg.data.key !== "active" && msg.data.type !== "transfer" && msg.data.username) {
             $("#keep_div").show();
             var prompt_msg = keyVerifyAction ? "Do not prompt again to verify keys for the @" + msg.data.username + " account on " + msg.domain :
                 "Do not prompt again to send " + msg.data.type + " transactions from the @" + msg.data.username + " account on " + msg.domain

--- a/js/dialog.js
+++ b/js/dialog.js
@@ -105,7 +105,7 @@ chrome.runtime.onMessage.addListener(function(msg, sender, sendResp) {
         $("#modal-content").css("align-items", "flex-start");
         const keyVerifyAction = msg.data.type == 'decode' || msg.data.type == 'signBuffer';
         console.log(msg.data.key);
-        if (msg.data.key !== "active" && msg.data.type !== "transfer" && msg.data.username) {
+        if (msg.data.key !== 'active' && msg.data.type !== 'transfer' && msg.data.type !== 'signBuffer') {
             $("#keep_div").show();
             var prompt_msg = keyVerifyAction ? "Do not prompt again to verify keys for the @" + msg.data.username + " account on " + msg.domain :
                 "Do not prompt again to send " + msg.data.type + " transactions from the @" + msg.data.username + " account on " + msg.domain

--- a/js/steem_keychain.js
+++ b/js/steem_keychain.js
@@ -20,11 +20,12 @@ var steem_keychain = {
         this.dispatchCustomEvent("swRequest", request, callback);
     },
 
-    requestSignBuffer: function(account, message, key, callback) {
+    requestSignBuffer: function(account, message, key, callback, enforce = false) {
         var request = {
             type: "signBuffer",
             username: account,
             message: message,
+            enforce: enforce,
             method: key
         };
 

--- a/js/web_interface.js
+++ b/js/web_interface.js
@@ -66,7 +66,7 @@ function sendResponse(response) {
 function validate(req) {
     return req != null && req != undefined && req.type != undefined && req.type != null &&
         ((req.type == "decode" && isFilled(req.username) && isFilled(req.message) && req.message[0] == "#" && isFilledKey(req.method)) ||
-            (req.type == "signBuffer" && isFilled(req.username) && isFilled(req.message) && isFilledKey(req.method)) ||
+            (req.type == "signBuffer" && isFilled(req.message) && isFilledKey(req.method) && checkEnforceUsername(req)) ||
             (req.type == "vote" && isFilled(req.username) && isFilledWeight(req.weight) && isFilled(req.permlink) && isFilled(req.author)) ||
             (req.type == "post" && isFilled(req.username) && isFilled(req.body) && 
                 ( (isFilled(req.title) && isFilledOrEmpty(req.permlink) && !isFilled(req.parent_username) && !isFilled(req.parent_perm) && isFilled(req.json_metadata)) ||
@@ -79,7 +79,7 @@ function validate(req) {
             (req.type == "signedCall" && isFilled(req.method) && isFilled(req.params) && isFilled(req.typeWif)) ||
             (req.type == "witnessVote" && isFilled(req.username) && isFilled(req.witness) && isBoolean(req.vote)) ||
             (req.type == "delegation" && isFilled(req.username) && isFilled(req.delegatee) && isFilledAmtSP(req) && isFilledDelegationMethod(req.unit)) ||
-            (req.type == "transfer" && isFilledAmt(req.amount) && isFilled(req.to) && isFilledCurrency(req.currency) && hasTransferInfo(req)) ||
+            (req.type == "transfer" && isFilledAmt(req.amount) && isFilled(req.to) && isFilledCurrency(req.currency) && checkEnforceUsername(req)) ||
             (req.type == "sendToken" && isFilledAmt(req.amount) && isFilled(req.to) && isFilled(req.currency))||
             (req.type == "powerUp" && isFilled(req.username)&& isFilledAmt(req.steem) && isFilled(req.recipient))||
             (req.type == "powerDown" && isFilled(req.username)&& (isFilledAmt(req.steem_power)||req.steem_power=="0.000"))
@@ -88,7 +88,7 @@ function validate(req) {
 
 // Functions used to check the incoming data
 
-function hasTransferInfo(req) {
+function checkEnforceUsername(req) {
     if (req.enforce)
         return isFilled(req.username);
     else if (isFilled(req.memo) && req.memo[0] == "#")


### PR DESCRIPTION
This will allow for websites to allow users to select the user from a dropdown instead of specifying the user ahead of time.

![image](https://user-images.githubusercontent.com/34953718/56944402-1471e700-6ad8-11e9-8007-111ca71f5955.png)

The response's data field will have the chosen username.

Example page is hosted https://eonwarped.github.io/steem/sk/main.html  as well.