### PR TITLE
add sender in transfer confirmation

### DIFF
--- a/html/popup.html
+++ b/html/popup.html
@@ -379,6 +379,8 @@
     <div id="confirm_send_div">
         <div class="back_enabled">Transfer</div>
         <p>Please confirm your transfer.<br>This cannot be undone.</p>
+        <h3>From</h3>
+        <div id="from_conf_transfer"></div>
         <h3>To</h3>
         <div id="to_conf_transfer"></div>
         <h3>Amount</h3>

--- a/js/background.js
+++ b/js/background.js
@@ -537,19 +537,19 @@ async function performTransaction(data, tab,no_confirm) {
             case "decode":
                 try {
                     let decoded = window.decodeMemo(key, data.message);
-                    console.log(decoded);
+                    
                     let message = {
                         command: "answerRequest",
                         msg: {
                             success: true,
                             error: null,
-                            result: "#"+decoded,
+                            result: decoded,
                             data: data,
                             message: "Memo decoded succesfully",
                             request_id: request_id
                         }
                     };
-                    console.log(no_confirm);
+                    
                     chrome.tabs.sendMessage(tab, message);
                     if(no_confirm){
                       if (id_win != null)

--- a/js/popup/popup.js
+++ b/js/popup/popup.js
@@ -188,6 +188,7 @@ function confirmTransfer(){
   const amount = $("#amt_send").val();
   const currency = $("#currency_send .select-selected").html();
   let memo = $("#memo_send").val();
+  $("#from_conf_transfer").text("@"+active_account.name)
   $("#to_conf_transfer").text("@"+to);
   $("#amt_conf_transfer").text(amount+" "+currency);
   $("#memo_conf_transfer").text((memo==""?"Empty":memo)+((memo!=""&&$("#encrypt_memo").prop("checked"))?" (encrypted)":""));

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Steem Keychain",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "Secure Steem Wallet Extension.",
   "permissions": ["activeTab", "declarativeContent", "storage", "tabs", "https://*/*", "notifications", "idle"],
   "browser_action": {


### PR DESCRIPTION
Close #96

![](https://user-images.githubusercontent.com/38183982/57197504-ebca7100-6f5f-11e9-875d-503bf9e36a9f.png)
> Currently, no sender is shown.

Thus, a user may choose a wrong sender account by mistake.

And as it says, it can't be undone. 

This PR adds the sender in the confirmation popup:

![](https://user-images.githubusercontent.com/38183982/57197502-e53bf980-6f5f-11e9-8b44-78bc2df8b0e4.png)
> The sender should be shown.(actual implementation screenshot)
