### PR TITLE
Enable enter key for adding account and key

### DIFF
--- a/js/popup/navigation.js
+++ b/js/popup/navigation.js
@@ -51,7 +51,7 @@ function initializeVisibility() {
     $(".dropdown").hide();
 }
 
-// Use "Enter" as confirmation button for unlocking and registration
+// Use "Enter" as confirmation button for unlocking, registration, and adding account/key
 $('#unlock_pwd').keypress(function(e) {
     if (e.keyCode == 13)
         $('#submit_unlock').click();
@@ -60,6 +60,16 @@ $('#unlock_pwd').keypress(function(e) {
 $('#confirm_master_pwd').keypress(function(e) {
     if (e.keyCode == 13)
         $('#submit_master_pwd').click();
+});
+
+$('#pwd').keypress(function(e) {
+    if (e.keyCode == 13)
+        $('#check_add_account').click();
+});
+
+$('#new_key').keypress(function(e) {
+    if (e.keyCode == 13)
+        $('#add_new_key').click();
 });
 
 // Clicking back after "forgot password"


### PR DESCRIPTION
Close #103

Enable enter key for adding account/key

Currently, enter key is working (for clicking the confirm button) only for unlocking and registration. So it doesn't work for adding account and key, which is inconvenient and inconsistent.

![](https://user-images.githubusercontent.com/38183982/57615995-0e1e4900-7575-11e9-9a14-c9e7030fb61d.png)
> enable enter key for adding account

![](https://user-images.githubusercontent.com/38183982/57616082-46258c00-7575-11e9-8f9c-5b8f51633df6.png)
> enable enter key for adding key