### PR TITLE
Add option to specify testnet

### DIFF
--- a/html/popup.html
+++ b/html/popup.html
@@ -308,19 +308,19 @@
     </div>
     <div id="pref_div" class="settings_child">
         <div class="back_enabled back_pref" style="font-size: 18px;">Preferences</div>
-        <h3>Select an RPC node</h1>
+        <h3>Select an RPC node</h3>
             <div class="custom-select no-img" id="custom_select_rpc">
                 <select>
-            </select>
+                </select>
             </div>
-            <h3>Notification Preferences</h1>
-                <div class="custom-select usernames" id="custom_select_pref">
-                    <select>
-            </select>
-                </div>
-                <div class="info">View and update the websites and transaction types for which you
-                    have opted not to recieve a confirmation prompt.</div>
-                <div id="pref">No preferences</div>
+        <h3>Notification Preferences</h3>
+            <div class="custom-select usernames" id="custom_select_pref">
+                <select>
+                </select>
+            </div>
+            <div class="info">View and update the websites and transaction types for which you
+                have opted not to recieve a confirmation prompt.</div>
+            <div id="pref">No preferences</div>
     </div>
     <div id="add_rpc_div">
         <div class="back_enabled">Add RPC</div>

--- a/js/background.js
+++ b/js/background.js
@@ -11,7 +11,7 @@ let autolock=null;
 let interval=null;
 // Lock after the browser is idle for more than 10 minutes
 
-chrome.storage.local.get(['current_rpc','autolock'], function(items) {
+chrome.storage.local.get(['current_rpc', 'autolock'], function(items) {
   if(items.autolock)
 		startAutolock(JSON.parse(items.autolock));
 
@@ -20,6 +20,14 @@ chrome.storage.local.get(['current_rpc','autolock'], function(items) {
 			uri: items.current_rpc || 'https://api.steemit.com',
 			url: items.current_rpc || 'https://api.steemit.com'
 	});
+    if (items.current_rpc === 'TESTNET') {
+        steem.api.setOptions({
+            url: 'https://testnet.steemitdev.com',
+            useAppbaseApi: true,
+        });
+        steem.config.set('address_prefix', 'TST');
+        steem.config.set('chain_id', '46d82ab7d8db682eb1959aed0ada039a6d49afa1602491f93dde9cac3e8e6c32');
+    }
 });
 
 chrome.webNavigation.onHistoryStateUpdated.addListener(function (details) {
@@ -80,10 +88,18 @@ function chromeMessageHandler(msg, sender, sendResp) {
         }, function(response) {});
     } else if (msg.command == "stopInterval") {
         clearInterval(interval);
-    }else if (msg.command == "setRPC") {
+    } else if (msg.command == "setRPC") {
         steem.api.setOptions({
             url: msg.rpc || 'https://api.steemit.com'
         });
+        if (msg.rpc === 'TESTNET') {
+            steem.api.setOptions({
+                url: 'https://testnet.steemitdev.com',
+                useAppbaseApi: true,
+            });
+            steem.config.set('address_prefix', 'TST');
+            steem.config.set('chain_id', '46d82ab7d8db682eb1959aed0ada039a6d49afa1602491f93dde9cac3e8e6c32');
+        }
     } else if (msg.command == "sendMk") { //Receive mk from the popup (upon registration or unlocking)
         mk = msg.mk;
     } else if (msg.command == "sendAutolock") {
@@ -787,7 +803,7 @@ function checkBeforeCreate(request, tab, domain) {
                     else if (tr_accounts.length==0){
                       createPopup(function() {
                           console.log("error3");
-                        sendErrors(tab, "user_cancel", "Request was canceled by the user.", "The current website is trying to send a transfer request to the Steem Keychain browser extension for account @" + request.username + " using the active key, which has not been added to the wallet.", request);
+                          sendErrors(tab, "user_cancel", "Request was canceled by the user.", "The current website is trying to send a transfer request to the Steem Keychain browser extension for account @" + request.username + " using the active key, which has not been added to the wallet.", request);
                       });
                     }
                     else {

--- a/js/popup/navigation.js
+++ b/js/popup/navigation.js
@@ -307,7 +307,7 @@ $("#send_steem").click(function() {
     $("#main").hide();
     $(".wallet_currency").removeClass('dropdown-open');
     $(".dropdown").hide();
-    $("#currency_send .select-selected").html("STEEM");
+    $("#currency_send .select-selected").html($("#currency_send select").children("option:first").text());
     $(".transfer_balance div").eq(0).text('STEEM Balance');
     $(".transfer_balance div").eq(1).html(numberWithCommas(steem_p));
 });
@@ -317,7 +317,7 @@ $("#send_sbd").click(function() {
     $("#main").hide();
     $(".wallet_currency").removeClass('dropdown-open');
     $(".dropdown").hide();
-    $("#currency_send .select-selected").html("SBD");
+    $("#currency_send .select-selected").html($("#currency_send select").children("option:nth-child(2)").text());
     $(".transfer_balance div").eq(0).text('SBD Balance');
     $(".transfer_balance div").eq(1).html(numberWithCommas(sbd));
 });

--- a/js/popup/popup.js
+++ b/js/popup/popup.js
@@ -43,6 +43,14 @@ chrome.runtime.onMessage.addListener(function(msg, sender, sendResp) {
             steem.api.setOptions({
                 url: items.current_rpc || 'https://api.steemit.com'
             });
+            if (items.current_rpc === 'TESTNET') {
+                steem.api.setOptions({
+                    url: 'https://testnet.steemitdev.com',
+                    useAppbaseApi: true,
+                });
+                steem.config.set('address_prefix', 'TST');
+                steem.config.set('chain_id', '46d82ab7d8db682eb1959aed0ada039a6d49afa1602491f93dde9cac3e8e6c32');
+            }
             if (msg.mk == null || msg.mk == undefined) {
                 if (items.accounts == null || items.accounts == undefined) {
                     showRegister();

--- a/js/popup/rpc.js
+++ b/js/popup/rpc.js
@@ -11,7 +11,8 @@ const RPCs = [
     "https://rpc.steemliberator.com",
     "https://rpc.steemviz.com",
     "https://steemd.minnowsupportproject.org",
-    "https://steemd.privex.io"
+    "https://steemd.privex.io",
+    "TESTNET"
 ];
 
 function loadRPC(local, current_rpc) {
@@ -34,6 +35,14 @@ function switchRPC(rpc) {
     steem.api.setOptions({
         url: rpc
     });
+    if (rpc === 'TESTNET') {
+        steem.api.setOptions({
+            url: 'https://testnet.steemitdev.com',
+            useAppbaseApi: true,
+        });
+        steem.config.set('address_prefix', 'TST');
+        steem.config.set('chain_id', '46d82ab7d8db682eb1959aed0ada039a6d49afa1602491f93dde9cac3e8e6c32');
+    }
     setRPC(rpc);
     chrome.storage.local.set({
         current_rpc: rpc
@@ -79,3 +88,4 @@ function showCustomRPC() {
         }
     });
 }
+

--- a/js/popup/rpc.js
+++ b/js/popup/rpc.js
@@ -29,6 +29,24 @@ function loadRPC(local, current_rpc) {
         return acc + "<option>" + val + "</option>";
     }, ""));
     $("#custom_select_rpc select").append("<option>ADD RPC</option>");
+    if (current_rpc === 'TESTNET') {
+        $("#currency_send select").children("option:first").text('TESTS');
+        $("#currency_send select").children("option:first").val('TESTS');
+        $("#currency_send select").children("option:nth-child(2)").text('TBD');
+        $("#currency_send select").children("option:nth-child(2)").val('TBD');
+        $('#wallet_currency .wallet_currency').eq(0).text('TESTS')
+        $('#wallet_currency .wallet_currency').eq(1).text('TBD')
+        $('#wallet_currency .wallet_currency').eq(2).text('TP')
+    } else {
+        $("#currency_send select").children("option:first").text('STEEM');
+        $("#currency_send select").children("option:first").val('STEEM');
+        $("#currency_send select").children("option:nth-child(2)").text('SBD');
+        $("#currency_send select").children("option:nth-child(2)").val('SBD');
+        $('#wallet_currency .wallet_currency').eq(0).text('STEEM')
+        $('#wallet_currency .wallet_currency').eq(1).text('SBD')
+        $('#wallet_currency .wallet_currency').eq(2).text('SP')
+
+    }
 }
 
 function switchRPC(rpc) {


### PR DESCRIPTION
It's basically setting the options hardcoded. May want to put different options but for now this allows for testing on the testnet.

![image](https://user-images.githubusercontent.com/34953718/61098569-0c4c0580-a492-11e9-9444-d4349fc10ed7.png)

Tested transfers, and delegation, and posting from custom testnet condenser with keychain support.